### PR TITLE
DPE-838: Enabling Spark service account configuration setup as k8s secrets

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -91,11 +91,13 @@ jobs:
         run: |
           sudo snap install spark-client_${{ env.SNAP_VERSION }}_amd64.snap --dangerous
 
-      - name: Setup Spark client
+      - name: Connect client interfaces
         run: |
           # connect interfaces
           sudo snap connect spark-client:dot-kube-config
-          
+
+      - name: Setup prerequisites
+        run: |
           # setup pre requisites
           sudo snap install microk8s --classic
           sudo microk8s status --wait-ready
@@ -106,7 +108,9 @@ jobs:
           sudo microk8s config > /home/runner/.kube/config
           sudo chown -f -R runner /home/runner/.kube
           sudo microk8s.enable dns
-          
+
+      - name: Setup client
+        run: |
           # create the service account
           spark-client.setup-spark-k8s service-account
 

--- a/helpers/setup-spark-k8s.py
+++ b/helpers/setup-spark-k8s.py
@@ -141,6 +141,10 @@ if __name__ == "__main__":
                                 help='Service Account for which configuration properties need to be retrieved.')
     parser_account.add_argument('--conf', action='append', type=str, help='Config property to retrieve.')
 
+    #  subparser for sa-conf-delete
+    parser_account = subparsers.add_parser('sa-conf-delete')
+    parser_account.add_argument('--service-account-name', default=None, help='Service Account for which configuration properties need to be deleted.')
+
     args = parser.parse_args()
 
     defaults = get_defaults_from_kubeconfig(args.kubeconfig or DEFAULT_KUBECONFIG, args.context)
@@ -154,4 +158,6 @@ if __name__ == "__main__":
         utils.setup_kubernetes_secret(args.properties_file, args.service_account_name)
     elif args.action == 'sa-conf-get':
         utils.retrieve_kubernetes_secret(args.service_account_name, args.conf)
+    elif args.action == 'sa-conf-delete':
+        utils.delete_kubernetes_secret(args.service_account_name)
 

--- a/helpers/setup-spark-k8s.py
+++ b/helpers/setup-spark-k8s.py
@@ -1,151 +1,12 @@
 #!/usr/bin/env python3
 
-import sys
-import os
-import yaml
 import argparse
-import pwd
-from typing import Dict
 import utils
 import logging
-
-KUBECTL_CMD= '{}/kubectl'.format(os.environ['SNAP'])
-USER_HOME_DIR_ENT_IDX = 5
-
-def print_help_for_missing_or_inaccessible_kubeconfig_file(kubeconfig: str):
-    print('\nERROR: Missing kubeconfig file {}. Or default kubeconfig file {}/.kube/config not found.'.format(kubeconfig, pwd.getpwuid(os.getuid())[5]))
-    print('\n')
-    print('Looks like either kubernetes is not set up properly or default kubeconfig file is not accessible!')
-    print('Please take the following remedial actions.')
-    print('	1. Please set up kubernetes and make sure kubeconfig file is available, accessible and correct.')
-    print('	2. sudo snap connect spark-client:dot-kube-config')
-
-def print_help_for_bad_kubeconfig_file(kubeconfig: str):
-    print('\nERROR: Invalid or incomplete kubeconfig file {}. One or more of the following entries might be missing or invalid.\n'.format(kubeconfig))
-    print('	- current-context')
-    print('	- context.name')
-    print('	- context.namespace')
-    print('	- context.cluster')
-    print('	- cluster.name')
-    print('	- cluster.server')
-    print(' - cluster.certificate-authority-data')
-    print('Please take the following remedial actions.')
-    print('	1. Please set up kubernetes and make sure kubeconfig file is available, accessible and correct.')
-    print('	2. sudo snap connect spark-client:dot-kube-config')
-
-def select_context_id(kube_cfg: Dict) -> int:
-    NO_CONTEXT = -1
-    SINGLE_CONTEXT = 0
-    context_names = [n['name'] for n in kube_cfg['contexts']]
-
-    selected_context_id = NO_CONTEXT
-    if len(context_names) == 1:
-        return SINGLE_CONTEXT
-
-    context_list_ux = '\n'.join(["{}. {}".format(context_names.index(a), a) for a in context_names])
-    while selected_context_id == NO_CONTEXT:
-        print (context_list_ux)
-        print('\nPlease select a kubernetes context by index:')
-        selected_context_id = input()
-
-        try:
-           int(selected_context_id)
-        except ValueError:
-            print('Invalid context index selection, please try again....')
-            selected_context_id = NO_CONTEXT
-            continue
-
-        if int(selected_context_id) not in range(len(context_names)):
-            print('Invalid context index selection, please try again....')
-            selected_context_id = NO_CONTEXT
-            continue
-
-    return int(selected_context_id)
-
-def get_defaults_from_kubeconfig(kubeconfig: str, context: str = None) -> Dict:
-    try:
-        with open(kubeconfig) as f:
-            kube_cfg = yaml.safe_load(f)
-            context_names = [n['name'] for n in kube_cfg['contexts']]
-            certs = [n['cluster']['certificate-authority-data'] for n in kube_cfg['clusters']]
-            current_context = context or kube_cfg['current-context']
-    except IOError as ioe:
-        print_help_for_missing_or_inaccessible_kubeconfig_file(kubeconfig)
-        sys.exit(-1)
-    except KeyError as ke:
-        print_help_for_bad_kubeconfig_file(kubeconfig)
-        sys.exit(-2)
-
-    try:
-        context_id = context_names.index(current_context)
-    except ValueError:
-        print(f'WARNING: Current context in provided kubeconfig file {kubeconfig} is invalid!')
-        print(f'\nProceeding with explicit context selection....')
-        context_id = select_context_id(kube_cfg)
-
-    defaults = {}
-    defaults['context'] = context_names[context_id]
-    defaults['namespace'] = 'default'
-    defaults['cert'] = certs[context_id]
-    defaults['config'] = kubeconfig
-    defaults['user'] = 'spark'
-
-    return defaults
-
-def set_up_user(username: str, name_space: str, defaults: Dict, mark_primary: bool) -> None:
-    namespace = name_space or defaults['namespace']
-    kubeconfig = defaults['config']
-    context_name = defaults['context']
-
-    rolebindingname = username + '-role'
-    roleaccess='view'
-    label = utils.get_management_label()
-
-    os.system(f"{KUBECTL_CMD} create serviceaccount --kubeconfig={kubeconfig} --context={context_name} {username} --namespace={namespace}")
-    os.system(f"{KUBECTL_CMD} create rolebinding --kubeconfig={kubeconfig} --context={context_name} {rolebindingname} --role={roleaccess}  --serviceaccount={namespace}:{username} --namespace={namespace}")
-
-    primary_label_to_remove = utils.get_primary_label(label=False)
-    primary_label_full = utils.get_primary_label()
-
-    primary = utils.retrieve_primary_service_account_details(namespace, context_name)
-    is_primary_defined = len(primary.keys()) > 0
-
-    logging.debug(f"is_primary_defined={is_primary_defined}")
-    logging.debug(f"mark_primary={mark_primary}")
-
-    if is_primary_defined and mark_primary:
-        sa_to_unlabel = primary['spark.kubernetes.authenticate.driver.serviceAccountName']
-        namespace_of_sa_to_unlabel = primary['spark.kubernetes.namespace']
-        rolebindingname_to_unlabel = sa_to_unlabel + '-role'
-
-        os.system(f"{KUBECTL_CMD} label serviceaccount --kubeconfig={kubeconfig} --context={context_name} --namespace={namespace_of_sa_to_unlabel} {sa_to_unlabel} {primary_label_to_remove}-")
-        os.system(f"{KUBECTL_CMD} label rolebinding --kubeconfig={kubeconfig} --context={context_name} --namespace={namespace_of_sa_to_unlabel} {rolebindingname_to_unlabel} {primary_label_to_remove}-")
-
-        os.system(f"{KUBECTL_CMD} label serviceaccount --kubeconfig={kubeconfig} --context={context_name} {username} {label} {primary_label_full} --namespace={namespace}")
-        os.system(f"{KUBECTL_CMD} label rolebinding --kubeconfig={kubeconfig} --context={context_name} {rolebindingname} {label} {primary_label_full} --namespace={namespace}")
-    elif is_primary_defined and not mark_primary:
-        os.system(f"{KUBECTL_CMD} label serviceaccount --kubeconfig={kubeconfig} --context={context_name} {username} {label} --namespace={namespace}")
-        os.system(f"{KUBECTL_CMD} label rolebinding --kubeconfig={kubeconfig} --context={context_name} {rolebindingname} {label} --namespace={namespace}")
-    elif not is_primary_defined:
-        os.system(f"{KUBECTL_CMD} label serviceaccount --kubeconfig={kubeconfig} --context={context_name} {username} {label} {primary_label_full} --namespace={namespace}")
-        os.system(f"{KUBECTL_CMD} label rolebinding --kubeconfig={kubeconfig} --context={context_name} {rolebindingname} {label} {primary_label_full} --namespace={namespace}")
-    else:
-        logging.warning("Labeling logic issue.....")
-
-
-def cleanup_user(username: str, namespace: str, k8s_context: str) -> None:
-    kubectl_cmd = utils.build_kubectl_cmd(namespace, k8s_context)
-    rolebindingname = username + '-role'
-
-    os.system(f"{kubectl_cmd} delete serviceaccount {username}")
-    os.system(f"{kubectl_cmd} delete rolebinding {rolebindingname}")
-    utils.delete_kubernetes_secret(username, namespace, k8s_context)
 
 if __name__ == "__main__":
     logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
 
-    USER_HOME_DIR = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
-    DEFAULT_KUBECONFIG = f'{USER_HOME_DIR}/.kube/config'
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--kubeconfig", default=None, help='Kubernetes configuration file')
@@ -165,7 +26,7 @@ if __name__ == "__main__":
     #  subparser for service-account-cleanup
     parser_account = subparsers.add_parser('service-account-cleanup')
 
-    #  subparser for sa-conf-put
+    #  subparser for sa-conf-create
     parser_account = subparsers.add_parser('sa-conf-create')
     parser_account.add_argument('--properties-file', default = None, help='File with all configuration properties assignments.')
     parser_account.add_argument('--conf', action='append', type=str, help='Config properties to be added to the service account.')
@@ -177,35 +38,27 @@ if __name__ == "__main__":
     #  subparser for sa-conf-del
     parser_account = subparsers.add_parser('sa-conf-delete')
 
-    # #  subparser for resources-sa
-    # parser_account = subparsers.add_parser('resources-sa')
-
     #  subparser for resources-primary-sa
     parser_account = subparsers.add_parser('resources-primary-sa')
 
     args = parser.parse_args()
 
-    defaults = get_defaults_from_kubeconfig(args.kubeconfig or DEFAULT_KUBECONFIG, args.context)
+    defaults = utils.get_defaults_from_kubeconfig(args.kubeconfig, args.context)
     
     if args.action == 'service-account':
-        username = args.username
-        namespace = args.namespace or defaults['namespace']
-        set_up_user(username, namespace, defaults, args.primary)
-        utils.setup_kubernetes_secret(username, namespace, args.context, args.properties_file, args.conf)
+        utils.set_up_user(args.username, args.namespace, args.kubeconfig, args.context, defaults, args.primary)
+        utils.setup_kubernetes_secret(args.username, args.namespace, args.kubeconfig, args.context, args.properties_file, args.conf)
     elif args.action == 'service-account-cleanup':
-        cleanup_user(args.username, args.namespace, args.context)
+        utils.cleanup_user(args.username, args.namespace, args.kubeconfig, args.context)
     elif args.action == 'sa-conf-create':
-        utils.delete_kubernetes_secret(args.username, args.namespace, args.context)
-        utils.setup_kubernetes_secret(args.username, args.namespace or defaults['namespace'], args.context, args.properties_file, args.conf)
+        utils.delete_kubernetes_secret(args.username, args.namespace, args.kubeconfig, args.context)
+        utils.setup_kubernetes_secret(args.username, args.namespace, args.kubeconfig, args.context, args.properties_file, args.conf)
     elif args.action == 'sa-conf-get':
-        conf = utils.retrieve_kubernetes_secret(args.username, args.namespace, args.context, args.conf)
+        conf = utils.retrieve_kubernetes_secret(args.username, args.namespace, args.kubeconfig, args.context, args.conf)
         utils.print_properties(conf)
     elif args.action == 'sa-conf-delete':
-        utils.delete_kubernetes_secret(args.username, args.namespace, args.context)
-    # elif args.action == 'resources-sa':
-    #     conf = utils.retrieve_k8s_resources_by_label(args.namespace, args.context)
-    #     utils.print_properties(conf)
+        utils.delete_kubernetes_secret(args.username, args.namespace, args.kubeconfig, args.context)
     elif args.action == 'resources-primary-sa':
-        conf = utils.retrieve_primary_service_account_details(args.namespace, args.context)
+        conf = utils.retrieve_primary_service_account_details(args.namespace, args.kubeconfig, args.context)
         utils.print_properties(conf)
 

--- a/helpers/setup-spark-k8s.py
+++ b/helpers/setup-spark-k8s.py
@@ -130,6 +130,17 @@ if __name__ == "__main__":
     parser_account.add_argument('--username', default='spark', help='Service account username to be created in kubernetes. Default is spark')
     parser_account.add_argument('--namespace', default=None, help='Namespace for the service account to be created in kubernetes. Default is default namespace')
 
+    #  subparser for sa-conf-create
+    parser_account = subparsers.add_parser('sa-conf-create')
+    parser_account.add_argument('--service-account-name', default=None, help='Service Account for which configuration properties need to be initialized.')
+    parser_account.add_argument('--properties-file', default = None, help='File with all configuration properties assignments.')
+
+    #  subparser for sa-conf-get
+    parser_account = subparsers.add_parser('sa-conf-get')
+    parser_account.add_argument('--service-account-name', default=None,
+                                help='Service Account for which configuration properties need to be retrieved.')
+    parser_account.add_argument('--conf', action='append', type=str, help='Config property to retrieve.')
+
     args = parser.parse_args()
 
     defaults = get_defaults_from_kubeconfig(args.kubeconfig or DEFAULT_KUBECONFIG, args.context)
@@ -139,3 +150,8 @@ if __name__ == "__main__":
         namespace = args.namespace or defaults['namespace']
         set_up_user(username, namespace, defaults)
         setup_spark_conf_defaults(username, namespace)
+    elif args.action == 'sa-conf-create':
+        utils.setup_kubernetes_secret(args.properties_file, args.service_account_name)
+    elif args.action == 'sa-conf-get':
+        utils.retrieve_kubernetes_secret(args.service_account_name, args.conf)
+

--- a/helpers/spark-submit.py
+++ b/helpers/spark-submit.py
@@ -13,6 +13,8 @@ if __name__ == "__main__":
     parser.add_argument("--master", default=None, type=str, help='Kubernetes control plane uri.')
     parser.add_argument("--deploy-mode", default="client", type=str, help='Deployment mode for job submission. Default is \'client\'.')
     parser.add_argument("--properties-file", default=None, type=str, help='Spark default configuration properties file.')
+    parser.add_argument("--username", default=None, type=str, help='Service account name to use other than primary.')
+    parser.add_argument("--namespace", default=None, type=str, help='Namespace of service account name to use other than primary.')
     args, extra_args = parser.parse_known_args()
 
     os.environ["HOME"] = pwd.getpwuid(os.getuid())[utils.USER_HOME_DIR_ENT_IDX]
@@ -23,7 +25,7 @@ if __name__ == "__main__":
     ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
 
     snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
-    dynamic_defaults = utils.get_dynamic_defaults()
+    dynamic_defaults = utils.get_dynamic_defaults(args.username, args.namespace)
     env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE)
     props_file_arg_defaults = utils.read_property_file(args.properties_file)
 

--- a/helpers/spark-submit.py
+++ b/helpers/spark-submit.py
@@ -6,10 +6,6 @@ import logging
 import argparse
 import utils
 
-USER_HOME_DIR_ENT_IDX = 5
-EXIT_CODE_BAD_KUBECONFIG = -100
-EXIT_CODE_BAD_CONF_ARG = -200
-
 if __name__ == "__main__":
     logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
 
@@ -19,7 +15,7 @@ if __name__ == "__main__":
     parser.add_argument("--properties-file", default=None, type=str, help='Spark default configuration properties file.')
     args, extra_args = parser.parse_known_args()
 
-    os.environ["HOME"] = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
+    os.environ["HOME"] = pwd.getpwuid(os.getuid())[utils.USER_HOME_DIR_ENT_IDX]
     if os.environ.get('SPARK_HOME') is None or os.environ.get('SPARK_HOME') == '':
         os.environ['SPARK_HOME'] = os.environ['SNAP']
 

--- a/helpers/spark-submit.py
+++ b/helpers/spark-submit.py
@@ -24,11 +24,10 @@ if __name__ == "__main__":
         os.environ['SPARK_HOME'] = os.environ['SNAP']
 
     STATIC_DEFAULTS_CONF_FILE = utils.get_static_defaults_conf_file()
-    DYNAMIC_DEFAULTS_CONF_FILE = utils.get_dynamic_defaults_conf_file()
     ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
 
     snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
-    setup_dynamic_defaults = utils.read_property_file(DYNAMIC_DEFAULTS_CONF_FILE) if os.path.isfile(DYNAMIC_DEFAULTS_CONF_FILE) else dict()
+    setup_dynamic_defaults = utils.retrieve_primary_service_account_details()
     env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE) if ENV_DEFAULTS_CONF_FILE and os.path.isfile(ENV_DEFAULTS_CONF_FILE) else dict()
     props_file_arg_defaults = utils.read_property_file(args.properties_file) if args.properties_file else dict()
 

--- a/helpers/spark-submit.py
+++ b/helpers/spark-submit.py
@@ -25,18 +25,14 @@ if __name__ == "__main__":
 
     STATIC_DEFAULTS_CONF_FILE = utils.get_static_defaults_conf_file()
     ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
-    primary = utils.retrieve_primary_service_account_details()
-    primary_username = primary['spark.kubernetes.authenticate.driver.serviceAccountName']
-    primary_namespace = primary['spark.kubernetes.namespace']
 
     snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
-    setup_dynamic_defaults = utils.retrieve_primary_service_account_details()
-    setup_dynamic_defaults_conf = utils.retrieve_kubernetes_secret(primary_username, primary_namespace, None, None)
-    env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE) if ENV_DEFAULTS_CONF_FILE and os.path.isfile(ENV_DEFAULTS_CONF_FILE) else dict()
-    props_file_arg_defaults = utils.read_property_file(args.properties_file) if args.properties_file else dict()
+    dynamic_defaults = utils.get_dynamic_defaults()
+    env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE)
+    props_file_arg_defaults = utils.read_property_file(args.properties_file)
 
     with utils.UmaskNamedTemporaryFile(mode = 'w', prefix='spark-conf-', suffix='.conf') as t:
-        defaults = utils.merge_configurations([snap_static_defaults, setup_dynamic_defaults, setup_dynamic_defaults_conf, env_defaults, props_file_arg_defaults])
+        defaults = utils.merge_configurations([snap_static_defaults, dynamic_defaults, env_defaults, props_file_arg_defaults])
         logging.debug(f'Spark props available for reference at {utils.get_snap_temp_dir()}{t.name}\n')
         utils.write_property_file(t.file, defaults, log=True)
         t.flush()

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -9,10 +9,13 @@ import subprocess
 import logging
 import io
 from tempfile import NamedTemporaryFile
+import yaml
 
 USER_HOME_DIR_ENT_IDX = 5
 EXIT_CODE_BAD_KUBECONFIG = -100
 EXIT_CODE_BAD_CONF_ARG = -200
+EXIT_CODE_GET_SECRET_FAILED = -300
+EXIT_CODE_PUT_SECRET_FAILED = -400
 
 def generate_spark_default_conf() -> Dict:
     generated_defaults = dict()
@@ -82,11 +85,19 @@ def reconstruct_submit_args(args: List, conf: Dict) -> List:
     submit_args = [conf_arg] + submit_args
     return submit_args
 
-def autodetect_kubernetes_master(conf: Dict) -> str:
+def get_kube_config() -> str:
     USER_HOME_DIR = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
     DEFAULT_KUBECONFIG = f'{USER_HOME_DIR}/.kube/config'
     kubeconfig = os.environ.get('KUBECONFIG') or DEFAULT_KUBECONFIG
+    return kubeconfig
+
+def get_kubectl_cmd() -> str:
     kubectl_cmd = '{}/kubectl'.format(os.environ['SNAP'])
+    return kubectl_cmd
+
+def autodetect_kubernetes_master(conf: Dict) -> str:
+    kubeconfig = get_kube_config()
+    kubectl_cmd = get_kubectl_cmd()
     context = conf.get('spark.kubernetes.context')
     if context:
         master_kubectl_cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig} --context {context} config view --minify -o jsonpath=\"{{.clusters[0]['cluster.server']}}\""
@@ -108,3 +119,46 @@ def UmaskNamedTemporaryFile(*args, **kargs):
     os.umask(umask)
     os.chmod(fdesc.name, 0o666 & ~umask)
     return fdesc
+
+def setup_kubernetes_secret(properties_file: str, service_account_name: str) -> None:
+    if not properties_file:
+        return
+    kubeconfig = get_kube_config()
+    kubectl_cmd = get_kubectl_cmd()
+    secret_name = f"spark-client-sa-conf-{service_account_name or 'spark'}"
+    cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig} create secret generic {secret_name} --from-env-file={properties_file}"
+    try:
+        subprocess.check_output(cmd, shell=True)
+    except subprocess.CalledProcessError as e:
+        logging.error(
+            f'Cannot create secret. Probably bad or missing kubeconfig file {kubeconfig}')
+        logging.warning(
+            f'Please set the KUBECONFIG environment variable to point to the kubeconfig. Or fix the default kubeconfig {kubeconfig}')
+        logging.error(e.output)
+        sys.exit(EXIT_CODE_BAD_KUBECONFIG)
+
+def retrieve_kubernetes_secret(service_account_name: str, keys: List[str]) -> None:
+    secret_name = f"spark-client-sa-conf-{service_account_name or 'spark'}"
+    kubeconfig = get_kube_config()
+    kubectl_cmd = get_kubectl_cmd()
+
+    if not keys or len(keys) == 0:
+        cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig} get secret {secret_name} -o yaml"
+        try:
+            out = subprocess.check_output(cmd, shell=True)
+            secret = yaml.safe_load(out.decode("utf-8"))
+            keys = secret['data'].keys()
+        except subprocess.CalledProcessError as e:
+            logging.error(e.output)
+            sys.exit(EXIT_CODE_GET_SECRET_FAILED)
+
+    for k in keys:
+        k1 = k.replace('.', '\\.')
+        cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig} get secret {secret_name} -o jsonpath='{{.data.{k1}}}' | base64 --decode"
+        try:
+            out = subprocess.check_output(cmd, shell=True)
+            v = out.decode("utf-8")
+            print(f"{k}={v}")
+        except subprocess.CalledProcessError as e:
+            logging.error(e.output)
+            sys.exit(EXIT_CODE_GET_SECRET_FAILED)

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -24,6 +24,11 @@ EXIT_CODE_GET_PRIMARY_RESOURCES_FAILED = -800
 EXIT_CODE_SET_PRIMARY_RESOURCES_FAILED = -900
 
 def read_property_file_unsafe(name: str) -> Dict :
+    """Rread properties in given file into a dictionary.
+
+    Args:
+        name: file name to be read
+    """
     defaults = dict()
     with open(name) as f:
         for line in f:
@@ -34,9 +39,21 @@ def read_property_file_unsafe(name: str) -> Dict :
     return defaults
 
 def read_property_file(name: str) -> Dict:
+    """Safely read properties in given file into a dictionary.
+
+    Args:
+        name: file name to be read safely
+    """
     return read_property_file_unsafe(name) if name and os.path.isfile(name) else dict()
 
 def write_property_file(fp: io.TextIOWrapper, props: Dict, log: bool = None) -> None:
+    """Write a given dictionary to provided file descriptor.
+
+    Args:
+        fp: file pointer to write to
+        props: config properties to be written
+        log: additionally print to screen
+    """
     for k in props.keys():
         v = props[k]
         line = f"{k}={v.strip()}"
@@ -45,32 +62,43 @@ def write_property_file(fp: io.TextIOWrapper, props: Dict, log: bool = None) -> 
             logging.info(line)
 
 def print_properties(props: Dict) -> None:
+    """Print a given dictionary to screen."""
     for k in props.keys():
         v = props[k]
         print(f"{k}={v}")
 
 def merge_configurations(dictionaries_to_merge: List[Dict]) -> Dict:
+    """Merges a given list of dictionaries, properties in subsequent ones override the properties in prior ones in the dictionary list."""
     result = dict()
     for override in dictionaries_to_merge:
         result.update(override)
     return result
 
 def get_static_defaults_conf_file() -> str:
+    """Returns static config properties file packaged with the client snap."""
     SPARK_STATIC_DEFAULTS_FILE = f"{os.environ.get('SNAP')}/conf/spark-defaults.conf"
     return SPARK_STATIC_DEFAULTS_FILE
 
 def get_dynamic_defaults_conf_file() -> str:
+    """Returns dynamic config properties file geenrated during client setup."""
     SPARK_DYNAMIC_DEFAULTS_FILE = f"{os.environ.get('SNAP_USER_DATA')}/spark-defaults.conf"
     return SPARK_DYNAMIC_DEFAULTS_FILE
 
 def get_env_defaults_conf_file() -> str:
+    """Returns env var provided by user to point to the config properties file with conf overrides."""
     SPARK_ENV_DEFAULTS_FILE = os.environ.get('SNAP_SPARK_ENV_CONF')
     return SPARK_ENV_DEFAULTS_FILE
 
 def get_snap_temp_dir() -> str:
+    """Returns /tmp directory as seen by the snap, for user's reference."""
     return '/tmp/snap.spark-client'
 
 def parse_conf_overrides(conf_args: List) -> Dict:
+    """Parse --conf overrides passed to spark-submit
+
+    Args:
+        conf_args: list of all --conf 'k1=v1' type args passed to spark-submit. Note v1 expression itself could be containing '='
+    """
     conf_overrides = dict()
     if conf_args:
         for c in conf_args:
@@ -85,6 +113,12 @@ def parse_conf_overrides(conf_args: List) -> Dict:
     return conf_overrides
 
 def reconstruct_submit_args(args: List, conf: Dict) -> List:
+    """Adding back possibly overridden config properties to list of other spark-submit arguments
+
+    Args:
+        args: regular args passed to spark-submit
+        conf: dictionary of all additional config (possible after overrides) to be passed to spark-submit.
+    """
     submit_args = args
     conf_arg = ''
     for k in conf.keys():
@@ -93,16 +127,23 @@ def reconstruct_submit_args(args: List, conf: Dict) -> List:
     return submit_args
 
 def get_kube_config() -> str:
+    """Returns default kubeconfig to use if not explicitly provided."""
     USER_HOME_DIR = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
     DEFAULT_KUBECONFIG = f'{USER_HOME_DIR}/.kube/config'
     kubeconfig = os.environ.get('KUBECONFIG') or DEFAULT_KUBECONFIG
     return kubeconfig
 
 def get_kubectl_cmd() -> str:
+    """Returns the kubectl binary location within the snap, used to build k8s commands."""
     kubectl_cmd = '{}/kubectl'.format(os.environ['SNAP'])
     return kubectl_cmd
 
 def autodetect_kubernetes_master(conf: Dict) -> str:
+    """Return a kubernetes master for use with spark-submit in case not provided.
+
+    Args:
+        config: dictionary of all config available to spark-submit.
+    """
     kubeconfig = get_kube_config()
     namespace = conf.get('spark.kubernetes.namespace')
     context = conf.get('spark.kubernetes.context')
@@ -114,6 +155,7 @@ def autodetect_kubernetes_master(conf: Dict) -> str:
     return f'k8s://{default_master}'
 
 def UmaskNamedTemporaryFile(*args, **kargs):
+    """Return a temporary file descriptor readable by all users."""
     fdesc = NamedTemporaryFile(*args, **kargs)
     umask = os.umask(0o666)
     os.umask(umask)
@@ -121,6 +163,13 @@ def UmaskNamedTemporaryFile(*args, **kargs):
     return fdesc
 
 def build_kubectl_cmd(kube_config: str, namespace: str, k8s_context: str) -> str:
+    """Returns a kubectl based command prefix to be used to construct various commands to run.
+
+    Args:
+        kube_config: config to be used for kuberntes
+        namespace: namespace for which kubectl command will run
+        k8s_context = kubernetes context of choice
+    """
     kubeconfig = kube_config or get_kube_config()
     kubectl_cmd = get_kubectl_cmd()
     cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig}"
@@ -131,9 +180,21 @@ def build_kubectl_cmd(kube_config: str, namespace: str, k8s_context: str) -> str
     return cmd
 
 def build_secret_name(username: str) -> str:
+    """Returns the secret name associated with a service account associated with the provided username.
+
+    Args:
+        username: username to indicate the service account for which secret name has to be returned
+    """
     return f"spark-client-sa-conf-{username or 'spark'}"
 
 def execute_kubectl_cmd(cmd: str, exit_code_on_error: int, log_on_error: bool = True) -> str:
+    """Execute provided kubectl command
+
+    Args:
+        cmd: Command to execute
+        exit_code_on_error: On error, sys.exit() called with this code.
+        log_on_error: boolean can be turned off for silent behavior i.e. no logging on error
+    """
     logging.debug(cmd)
     # kubeconfig = get_kube_config()
     try:
@@ -147,6 +208,16 @@ def execute_kubectl_cmd(cmd: str, exit_code_on_error: int, log_on_error: bool = 
     return result
 
 def setup_kubernetes_secret(username: str, namespace: str, kubeconfig: str, k8s_context: str, properties_file: str, conf : List[str]) -> None:
+    """Store/set up properties against a service account (as secrets)
+
+    Args:
+        username: username corresponding to the service account for which config properties are to be stored
+        name_space: namespace of the provided username.
+        kube_config: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+        properties_file: file to pick up config properties from
+        conf: list of additional config properties to add/override ones in properties file provided
+    """
     kubectl_cmd = build_kubectl_cmd(kubeconfig, namespace, k8s_context)
     secret_name = build_secret_name(username)
     props_from_file = read_property_file(properties_file)
@@ -161,6 +232,15 @@ def setup_kubernetes_secret(username: str, namespace: str, kubeconfig: str, k8s_
         execute_kubectl_cmd(cmd, EXIT_CODE_PUT_SECRET_ENV_FILE_FAILED)
 
 def retrieve_kubernetes_secret(username: str, namespace: str, kubeconfig: str, k8s_context: str, keys: List[str]) -> Dict:
+    """Retrieve the decoded config properties stored against a service account (as secrets)
+
+    Args:
+        username: username corresponding to the service account for which config properties are to be retrieved
+        name_space: namespace of the provided username.
+        kube_config: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+        keys: list of specific keys for which this operation is requested. If not available, all config properties retrieved
+    """
     if not username:
         return dict()
 
@@ -182,18 +262,43 @@ def retrieve_kubernetes_secret(username: str, namespace: str, kubeconfig: str, k
     return result
 
 def delete_kubernetes_secret(username: str, namespace: str, kubeconfig: str, k8s_context: str) -> None:
+    """Delete the config properties stored against a service account (as secrets)
+
+    Args:
+        username: username corresponding to the service account for which config properties are to be deleted
+        name_space: namespace of the provided username.
+        kube_config: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+    """
     kubectl_cmd = build_kubectl_cmd(kubeconfig, namespace, k8s_context)
     secret_name = build_secret_name(username)
     cmd = f"{kubectl_cmd} delete secret {secret_name}"
     execute_kubectl_cmd(cmd, EXIT_CODE_DEL_SECRET_FAILED, log_on_error=False)
 
 def get_management_label(label: bool = True) -> str:
+    """Returns uber spark-client management label
+
+    Args:
+        label: bool to be turned off to retrieve the label fragment for unlabel command
+    """
     return 'app.kubernetes.io/managed-by=spark-client' if label else 'app.kubernetes.io/managed-by'
 
 def get_primary_label(label: bool = True) -> str:
+    """Returns label used to mark the primary service account.
+
+    Args:
+        label: bool to be turned off to retrieve the label fragment for unlabel command
+    """
     return 'app.kubernetes.io/spark-client-primary=1' if label else 'app.kubernetes.io/spark-client-primary'
 
 def retrieve_primary_service_account_details(namespace: str, kubeconfig: str, k8s_context: str) -> Dict:
+    """Boolean to check if a primary service account has been defined.
+
+    Args:
+        namespace: namespace to point to the service account
+        kubeconfig: kubernetes config for kubectl command
+        k8s_context: kubernetes context to be used
+    """
     kubectl_cmd = build_kubectl_cmd(kubeconfig, namespace, k8s_context)
     label = get_primary_label()
     cmd = f"{kubectl_cmd}  get serviceaccount -l {label} -A -o yaml"
@@ -206,10 +311,23 @@ def retrieve_primary_service_account_details(namespace: str, kubeconfig: str, k8
     return result
 
 def is_primary_sa_defined(namespace: str, kubeconfig: str, k8s_context: str) -> bool:
+    """Boolean to check if a primary service account has been defined.
+
+    Args:
+        user_name: username to point to the service account
+        kubeconfig: kubernetes config for kubectl command
+        k8s_context: kubernetes context to be used
+    """
     conf = retrieve_primary_service_account_details(namespace, kubeconfig, k8s_context)
     return len(conf.keys()) > 0
 
-def get_dynamic_defaults(user_name: str, name_space: str):
+def get_dynamic_defaults(user_name: str, name_space: str) -> Dict:
+    """Get setup scripts generated config values overridden with config properties kept in the service account.
+
+    Args:
+        user_name: username to point to the service account and it's secret config properties
+        name_space: namespace of the username provided
+    """
     kubeconfig = get_kube_config()
     setup_dynamic_defaults = retrieve_primary_service_account_details(None, kubeconfig, None)
     username = user_name or setup_dynamic_defaults.get('spark.kubernetes.authenticate.driver.serviceAccountName')
@@ -220,7 +338,12 @@ def get_dynamic_defaults(user_name: str, name_space: str):
     return merge_configurations([setup_dynamic_defaults, setup_dynamic_defaults_conf])
 
 
-def print_help_for_missing_or_inaccessible_kubeconfig_file(kubeconfig: str):
+def print_help_for_missing_or_inaccessible_kubeconfig_file(kubeconfig: str) -> None:
+    """Helpful error message for the user indicating expected kubeconfig is missing or inaccessible.
+
+    Args:
+        kubeconfig: config for kubectl command execution pointing to the right k8s cluster
+    """
     print('\nERROR: Missing kubeconfig file {}. Or default kubeconfig file {}/.kube/config not found.'.format(kubeconfig, pwd.getpwuid(os.getuid())[5]))
     print('\n')
     print('Looks like either kubernetes is not set up properly or default kubeconfig file is not accessible!')
@@ -228,7 +351,13 @@ def print_help_for_missing_or_inaccessible_kubeconfig_file(kubeconfig: str):
     print('	1. Please set up kubernetes and make sure kubeconfig file is available, accessible and correct.')
     print('	2. sudo snap connect spark-client:dot-kube-config')
 
-def print_help_for_bad_kubeconfig_file(kubeconfig: str):
+
+def print_help_for_bad_kubeconfig_file(kubeconfig: str) -> None:
+    """Helpful error message for the user indicating kubeconfig provided might be corrupted.
+
+    Args:
+        kubeconfig: config for kubectl command execution pointing to the right k8s cluster
+    """
     print('\nERROR: Invalid or incomplete kubeconfig file {}. One or more of the following entries might be missing or invalid.\n'.format(kubeconfig))
     print('	- current-context')
     print('	- context.name')
@@ -242,6 +371,11 @@ def print_help_for_bad_kubeconfig_file(kubeconfig: str):
     print('	2. sudo snap connect spark-client:dot-kube-config')
 
 def select_context_id(kube_cfg: Dict) -> int:
+    """Interact with user to select a context from the kube config provided.
+
+    Args:
+        kube_cfg: config for kubectl command execution pointing to the right k8s cluster
+    """
     NO_CONTEXT = -1
     SINGLE_CONTEXT = 0
     context_names = [n['name'] for n in kube_cfg['contexts']]
@@ -271,6 +405,12 @@ def select_context_id(kube_cfg: Dict) -> int:
     return int(selected_context_id)
 
 def get_defaults_from_kubeconfig(kube_config: str, context: str = None) -> Dict:
+    """Get config defaults from kubernetes config and context.
+
+    Args:
+        kube_config: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+    """
     USER_HOME_DIR = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
     DEFAULT_KUBECONFIG = f'{USER_HOME_DIR}/.kube/config'
     kubeconfig = kube_config or DEFAULT_KUBECONFIG
@@ -304,6 +444,16 @@ def get_defaults_from_kubeconfig(kube_config: str, context: str = None) -> Dict:
     return defaults
 
 def set_up_user(username: str, name_space: str, kube_config: str, k8s_context: str, defaults: Dict, mark_primary: bool) -> None:
+    """Setup all resources related to a service account.
+
+    Args:
+        username: username corresponding to the service account to be set up.
+        name_space: namespace of the provided username.
+        kube_config: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+        defaults: config to fallback on in case any parameters not supplied
+        mark_primary: boolean to indicate if this service account needs to be marked primary
+    """
     namespace = name_space or defaults['namespace']
     kubeconfig = kube_config or defaults['config']
     context_name = k8s_context or defaults['context']
@@ -347,6 +497,14 @@ def set_up_user(username: str, name_space: str, kube_config: str, k8s_context: s
 
 
 def cleanup_user(username: str, namespace: str, kubeconfig: str, k8s_context: str) -> None:
+    """Cleanup all resources related to a service account.
+
+    Args:
+        username: username corresponding to the service account to be cleaned up.
+        namespace: namespace of the provided username.
+        kubeconfig: config for kubectl command execution pointing to the right k8s cluster
+        k8s_context: context of user's choice from within the provided kubeconfig
+    """
     kubectl_cmd = build_kubectl_cmd(kubeconfig, namespace, k8s_context)
     rolebindingname = username + '-role'
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -16,6 +16,7 @@ EXIT_CODE_BAD_KUBECONFIG = -100
 EXIT_CODE_BAD_CONF_ARG = -200
 EXIT_CODE_GET_SECRET_FAILED = -300
 EXIT_CODE_PUT_SECRET_FAILED = -400
+EXIT_CODE_DEL_SECRET_FAILED = -500
 
 def generate_spark_default_conf() -> Dict:
     generated_defaults = dict()
@@ -162,3 +163,14 @@ def retrieve_kubernetes_secret(service_account_name: str, keys: List[str]) -> No
         except subprocess.CalledProcessError as e:
             logging.error(e.output)
             sys.exit(EXIT_CODE_GET_SECRET_FAILED)
+
+def delete_kubernetes_secret(service_account_name: str) -> None:
+    secret_name = f"spark-client-sa-conf-{service_account_name or 'spark'}"
+    kubeconfig = get_kube_config()
+    kubectl_cmd = get_kubectl_cmd()
+    cmd = f"{kubectl_cmd} --kubeconfig {kubeconfig} delete secret {secret_name}"
+    try:
+        subprocess.check_output(cmd, shell=True)
+    except subprocess.CalledProcessError as e:
+        logging.error(e.output)
+        sys.exit(EXIT_CODE_DEL_SECRET_FAILED)


### PR DESCRIPTION
We want to provide a way for the users to set configurations at the service account level, stored in kubernetes as secrets named “spark-client-sa-conf-${SERVICE_ACCOUNT}” with data as 

{“spark.executor.instances”: …}

We want to have some API to create or view properties 
setup_spark_k8s sa-conf-create --service-account-name SERVICE_ACCOUNT_NAME --properties-file PROPERTIES_FILE 
setup_spark_k8s sa-conf-get --service-account-name SERVICE_ACCOUNT_NAME [--conf]

Coming Soon:
Remove properties (except for the namespace and serviceaccount name)
