### PR TITLE
DPE-839: Introducing python wrapper for spark-shell within the snap.

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -148,7 +148,7 @@ jobs:
           echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> test-spark-shell.scala
           echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> test-spark-shell.scala
           echo "System.exit(0)" >> test-spark-shell.scala
-          spark-client.spark-shell  --conf spark.kubernetes.container.image=averma32/sparkrock:latest < test-spark-shell.scala > spark-shell.out
+          spark-client.spark-shell < test-spark-shell.scala > spark-shell.out
           pi=$(grep -v "scala>" spark-shell.out  | grep "Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
           echo -e "Spark-shell Pi Job Output: \n ${pi}"
           if [ "${pi}" != "3.14" ]; then

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -149,7 +149,7 @@ jobs:
           echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> test-spark-shell.scala
           echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> test-spark-shell.scala
           echo "System.exit(0)" >> test-spark-shell.scala
-          spark-client.spark-shell < test-spark-shell.scala > spark-shell.out
+          spark-client.spark-shell --conf spark.kubernetes.container.image=docker.io/averma32/sparkpy6:latest < test-spark-shell.scala > spark-shell.out
           pi=$(grep -v "scala>" spark-shell.out  | grep "Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
           echo -e "Spark-shell Pi Job Output: \n ${pi}"
           if [ "${pi}" != "3.14" ]; then

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -142,14 +142,14 @@ jobs:
 
       - name: Test spark-shell
         run: |
-          echo "import scala.math.random" > /home/runnner/test-spark-shell.scala
-          echo "val slices = 1000" >> /home/runnner/test-spark-shell.scala
-          echo "val n = math.min(100000L * slices, Int.MaxValue).toInt" >> /home/runnner/test-spark-shell.scala
-          echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> /home/runnner/test-spark-shell.scala
-          echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> /home/runnner/test-spark-shell.scala
-          echo "System.exit(0)" >> /home/runnner/test-spark-shell.scala
-          spark-client.spark-shell  --conf spark.kubernetes.container.image=averma32/sparkrock:latest < /home/runnner/test-spark-shell.scala > /home/runnner/spark-shell.out
-          pi=$(grep -v "scala>" /home/runnner/spark-shell.out  | grep "Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
+          echo "import scala.math.random" > test-spark-shell.scala
+          echo "val slices = 1000" >> test-spark-shell.scala
+          echo "val n = math.min(100000L * slices, Int.MaxValue).toInt" >> test-spark-shell.scala
+          echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> test-spark-shell.scala
+          echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> test-spark-shell.scala
+          echo "System.exit(0)" >> test-spark-shell.scala
+          spark-client.spark-shell  --conf spark.kubernetes.container.image=averma32/sparkrock:latest < test-spark-shell.scala > spark-shell.out
+          pi=$(grep -v "scala>" spark-shell.out  | grep "Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
           echo -e "Spark-shell Pi Job Output: \n ${pi}"
           if [ "${pi}" != "3.14" ]; then
               exit 1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -113,7 +113,8 @@ jobs:
       - name: Run example job
         run: |
           K8S_MASTER_URL=k8s://$(sudo kubectl --kubeconfig=/home/runner/.kube/config config view -o jsonpath="{.clusters[0]['cluster.server']}")
-          SPARK_EXAMPLES_JAR_NAME='spark-examples_2.12-3.4.0-SNAPSHOT.jar'
+          # SPARK_EXAMPLES_JAR_NAME='spark-examples_2.12-3.4.0-SNAPSHOT.jar'
+          SPARK_EXAMPLES_JAR_NAME='spark-examples_2.12-3.3.1.jar'
           
           # run the sample pi job using spark-submit
           spark-client.spark-submit \

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -140,6 +140,21 @@ jobs:
               exit 1
           fi
 
+      - name: Test spark-shell
+        run: |
+          echo "import scala.math.random" > /home/runnner/test-spark-shell.scala
+          echo "val slices = 1000" >> /home/runnner/test-spark-shell.scala
+          echo "val n = math.min(100000L * slices, Int.MaxValue).toInt" >> /home/runnner/test-spark-shell.scala
+          echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> /home/runnner/test-spark-shell.scala
+          echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> /home/runnner/test-spark-shell.scala
+          echo "System.exit(0)" >> /home/runnner/test-spark-shell.scala
+          spark-client.spark-shell  --conf spark.kubernetes.container.image=averma32/sparkrock:latest < /home/runnner/test-spark-shell.scala > /home/runnner/spark-shell.out
+          pi=$(grep -v "scala>" /home/runnner/spark-shell.out  | grep "Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
+          echo -e "Spark-shell Pi Job Output: \n ${pi}"
+          if [ "${pi}" != "3.14" ]; then
+              exit 1
+          fi
+
   publish:
     name: Publish Snap
     if: needs.build-condition.outputs.decision  ==  '1' && github.event_name == 'schedule'

--- a/helpers/spark-defaults.conf
+++ b/helpers/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.kubernetes.container.image=docker.io/averma32/sparkpy6:latest
+spark.kubernetes.container.image=docker.io/averma32/sparkrock:latest

--- a/helpers/spark-shell.py
+++ b/helpers/spark-shell.py
@@ -27,6 +27,8 @@ if __name__ == "__main__":
 
     snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
     setup_dynamic_defaults = utils.read_property_file(DYNAMIC_DEFAULTS_CONF_FILE) if os.path.isfile(DYNAMIC_DEFAULTS_CONF_FILE) else dict()
+    # TODO: User override of 'spark.driver.extraJavaOptions' will disturb the scala.shell.histfile. Needs to handled.
+    # TODO: Add documentation explaining this limitation and what to do in that case.
     setup_dynamic_defaults['spark.driver.extraJavaOptions'] = f'-Dscala.shell.histfile={SCALA_HISTORY_FILE}'
     env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE) if ENV_DEFAULTS_CONF_FILE and os.path.isfile(ENV_DEFAULTS_CONF_FILE) else dict()
     props_file_arg_defaults = utils.read_property_file(args.properties_file) if args.properties_file else dict()

--- a/helpers/spark-shell.py
+++ b/helpers/spark-shell.py
@@ -12,16 +12,39 @@ if __name__ == "__main__":
     logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--master", default=None, type=str, help='Kubernetes control plane uri.')
     parser.add_argument("--deploy-mode", default="client", type=str, help='Deployment mode for spark shell. Default is \'client\'.')
+    parser.add_argument("--properties-file", default=None, type=str, help='Spark default configuration properties file.')
     args, extra_args = parser.parse_known_args()
 
     os.environ["HOME"] = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
     if os.environ.get('SPARK_HOME') is None or os.environ.get('SPARK_HOME') == '':
         os.environ['SPARK_HOME'] = os.environ['SNAP']
 
-    SPARK_HOME = os.environ['SPARK_HOME']
-    SPARK_SHELL_ARGS = ' '.join(extra_args)
-    SCALA_HISTORY_FILE = utils.get_scala_shell_history_file()
-    shell_cmd = f'{SPARK_HOME}/bin/spark-shell --deploy-mode client --conf spark.driver.extraJavaOptions=\'-Dscala.shell.histfile={SCALA_HISTORY_FILE}\' {SPARK_SHELL_ARGS}'
-    logging.debug(shell_cmd)
-    os.system(shell_cmd)
+    STATIC_DEFAULTS_CONF_FILE = utils.get_static_defaults_conf_file()
+    DYNAMIC_DEFAULTS_CONF_FILE = utils.get_dynamic_defaults_conf_file()
+    ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
+
+    snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
+    setup_dynamic_defaults = utils.read_property_file(DYNAMIC_DEFAULTS_CONF_FILE) if os.path.isfile(DYNAMIC_DEFAULTS_CONF_FILE) else dict()
+    env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE) if ENV_DEFAULTS_CONF_FILE and os.path.isfile(ENV_DEFAULTS_CONF_FILE) else dict()
+    props_file_arg_defaults = utils.read_property_file(args.properties_file) if args.properties_file else dict()
+
+    with utils.UmaskNamedTemporaryFile(mode = 'w', prefix='spark-conf-', suffix='.conf') as t:
+        defaults = utils.merge_configurations([snap_static_defaults, setup_dynamic_defaults, env_defaults, props_file_arg_defaults])
+        SCALA_HISTORY_FILE = utils.get_scala_shell_history_file()
+        defaults['spark.driver.extraJavaOptions'] = f'-Dscala.shell.histfile={SCALA_HISTORY_FILE}'
+
+        logging.debug(f'Spark props available for reference at {utils.get_snap_temp_dir()}{t.name}\n')
+        utils.write_property_file(t.file, defaults, log=True)
+        t.flush()
+
+        shell_args = [ f'--master {args.master or utils.autodetect_kubernetes_master(defaults)}',
+                       f'--deploy-mode client',
+                       f'--properties-file {t.name}'] + extra_args
+
+        SPARK_HOME = os.environ['SPARK_HOME']
+        SPARK_SHELL_ARGS = ' '.join(shell_args)
+        shell_cmd = f'{SPARK_HOME}/bin/spark-shell {SPARK_SHELL_ARGS}'
+        logging.info(shell_cmd)
+        os.system(shell_cmd)

--- a/helpers/spark-shell.py
+++ b/helpers/spark-shell.py
@@ -12,8 +12,7 @@ if __name__ == "__main__":
     logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--master", default=None, type=str, help='Kubernetes control plane uri.')
-    parser.add_argument("--deploy-mode", default="client", type=str, help='Deployment mode for spark shell. Default is \'client\'.')
+    parser.add_argument("--master", default=None, type=str, help='Control plane uri.')
     parser.add_argument("--properties-file", default=None, type=str, help='Spark default configuration properties file.')
     args, extra_args = parser.parse_known_args()
 
@@ -24,23 +23,21 @@ if __name__ == "__main__":
     STATIC_DEFAULTS_CONF_FILE = utils.get_static_defaults_conf_file()
     DYNAMIC_DEFAULTS_CONF_FILE = utils.get_dynamic_defaults_conf_file()
     ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
+    SCALA_HISTORY_FILE = utils.get_scala_shell_history_file()
 
     snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
     setup_dynamic_defaults = utils.read_property_file(DYNAMIC_DEFAULTS_CONF_FILE) if os.path.isfile(DYNAMIC_DEFAULTS_CONF_FILE) else dict()
+    setup_dynamic_defaults['spark.driver.extraJavaOptions'] = f'-Dscala.shell.histfile={SCALA_HISTORY_FILE}'
     env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE) if ENV_DEFAULTS_CONF_FILE and os.path.isfile(ENV_DEFAULTS_CONF_FILE) else dict()
     props_file_arg_defaults = utils.read_property_file(args.properties_file) if args.properties_file else dict()
 
     with utils.UmaskNamedTemporaryFile(mode = 'w', prefix='spark-conf-', suffix='.conf') as t:
         defaults = utils.merge_configurations([snap_static_defaults, setup_dynamic_defaults, env_defaults, props_file_arg_defaults])
-        SCALA_HISTORY_FILE = utils.get_scala_shell_history_file()
-        defaults['spark.driver.extraJavaOptions'] = f'-Dscala.shell.histfile={SCALA_HISTORY_FILE}'
-
         logging.debug(f'Spark props available for reference at {utils.get_snap_temp_dir()}{t.name}\n')
         utils.write_property_file(t.file, defaults, log=True)
         t.flush()
 
         shell_args = [ f'--master {args.master or utils.autodetect_kubernetes_master(defaults)}',
-                       f'--deploy-mode client',
                        f'--properties-file {t.name}'] + extra_args
 
         SPARK_HOME = os.environ['SPARK_HOME']

--- a/helpers/spark-shell.py
+++ b/helpers/spark-shell.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import pwd
+import logging
+import argparse
+import utils
+
+USER_HOME_DIR_ENT_IDX = 5
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--deploy-mode", default="client", type=str, help='Deployment mode for spark shell. Default is \'client\'.')
+    args, extra_args = parser.parse_known_args()
+
+    os.environ["HOME"] = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
+    if os.environ.get('SPARK_HOME') is None or os.environ.get('SPARK_HOME') == '':
+        os.environ['SPARK_HOME'] = os.environ['SNAP']
+
+    SPARK_HOME = os.environ['SPARK_HOME']
+    SPARK_SHELL_ARGS = ' '.join(extra_args)
+    SCALA_HISTORY_FILE = utils.get_scala_shell_history_file()
+    shell_cmd = f'{SPARK_HOME}/bin/spark-shell --deploy-mode client --conf spark.driver.extraJavaOptions=\'-Dscala.shell.histfile={SCALA_HISTORY_FILE}\' {SPARK_SHELL_ARGS}'
+    logging.debug(shell_cmd)
+    os.system(shell_cmd)

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -57,6 +57,12 @@ def get_env_defaults_conf_file() -> str:
     SPARK_ENV_DEFAULTS_FILE = os.environ.get('SNAP_SPARK_ENV_CONF')
     return SPARK_ENV_DEFAULTS_FILE
 
+def get_scala_shell_history_file() -> str:
+    """Returns location of .scala_history file for spark-shell"""
+    USER_HOME_DIR = pwd.getpwuid(os.getuid())[USER_HOME_DIR_ENT_IDX]
+    SCALA_HIST_FILE_DIR = os.environ.get('SNAP_USER_DATA', USER_HOME_DIR)
+    return f'{SCALA_HIST_FILE_DIR}/.scala_history'
+
 def get_snap_temp_dir() -> str:
     return '/tmp/snap.spark-client'
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
         - network
         - network-bind
         - home
+        - dot-kube-config
   pyspark:
     command: bin/pyspark
     environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ apps:
         - home
         - dot-kube-config
   spark-shell:
-    command: bin/spark-shell
+    command: ops/spark-shell.py
     plugs:
         - network
         - network-bind
@@ -129,6 +129,8 @@ parts:
       chmod 755 "${target_dir}/setup-spark-k8s.py"
       cp spark-submit.py "${target_dir}/"
       chmod 755 "${target_dir}/spark-submit.py"
+      cp spark-shell.py "${target_dir}/"
+      chmod 755 "${target_dir}/spark-shell.py"
       cp utils.py "${target_dir}/"
       chmod 755 "${target_dir}/utils.py"
       


### PR DESCRIPTION
We want to create a wrapper for the “spark-shell” command, **building on the parsing of configurations and merging logic already implemented for spark-submit**

Main features:
1. deploy-mode: set to “client” in any case (as spark-shell should really not be run with deploy-mode set to “cluster”)
2. setting the .scala_history file location dynamically
- $SNAP_USER_DATA/.scala_history if SNAP_USER_DATA defined OR
- $HOME/.scala_history