### PR TITLE
DPE-840: Introducing pyspark wrapper.

### DIFF
--- a/helpers/pyspark.py
+++ b/helpers/pyspark.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import pwd
+
+import constants
+import utils
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--log-level", default="ERROR", type=str, help="Level for logging."
+    )
+    parser.add_argument(
+        "--username", default=None, type=str, help="Username of service account to use."
+    )
+    parser.add_argument(
+        "--namespace", default=None, type=str, help="Namespace of service account."
+    )
+    parser.add_argument("--master", default=None, type=str, help="Control plane uri.")
+    parser.add_argument(
+        "--properties-file",
+        default=None,
+        type=str,
+        help="Spark default configuration properties file.",
+    )
+    args, extra_args = parser.parse_known_args()
+
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(message)s", level=args.log_level
+    )
+
+    os.environ["HOME"] = str(pwd.getpwuid(os.getuid())[constants.USER_HOME_DIR_ENT_IDX])
+    if os.environ.get("SPARK_HOME") is None or os.environ.get("SPARK_HOME") == "":
+        os.environ["SPARK_HOME"] = os.environ["SNAP"]
+
+    STATIC_DEFAULTS_CONF_FILE = utils.get_static_defaults_conf_file()
+    ENV_DEFAULTS_CONF_FILE = utils.get_env_defaults_conf_file()
+
+    snap_static_defaults = utils.read_property_file(STATIC_DEFAULTS_CONF_FILE)
+    setup_dynamic_defaults = utils.get_dynamic_defaults(args.username, args.namespace)
+    env_defaults = utils.read_property_file(ENV_DEFAULTS_CONF_FILE)
+    props_file_arg_defaults = utils.read_property_file(args.properties_file)
+
+    with utils.UmaskNamedTemporaryFile(
+        mode="w", prefix="spark-conf-", suffix=".conf"
+    ) as t:
+        defaults = utils.merge_configurations(
+            [
+                snap_static_defaults,
+                setup_dynamic_defaults,
+                env_defaults,
+                props_file_arg_defaults,
+            ]
+        )
+        logging.debug(
+            f"Spark props available for reference at {utils.get_snap_temp_dir()}{t.name}\n"
+        )
+        utils.write_property_file(t.file, defaults, log=True)
+        t.flush()
+
+        pyspark_args = [
+            f"--master {args.master or utils.autodetect_kubernetes_master(defaults)}",
+            f"--properties-file {t.name}",
+        ] + extra_args
+
+        SPARK_HOME = os.environ["SPARK_HOME"]
+        PYSPARK_ARGS = " ".join(pyspark_args)
+        pyspark_cmd = f"{SPARK_HOME}/bin/pyspark {PYSPARK_ARGS}"
+        logging.info(pyspark_cmd)
+        os.system(pyspark_cmd)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: spark-client
-base: core20
+base: core22
 version: '3.3.1'
 summary: Client side scripts to submit Spark jobs to a cluster.
 description: |
@@ -45,13 +45,14 @@ apps:
         - home
         - dot-kube-config
   pyspark:
-    command: bin/pyspark
+    command: ops/pyspark.py
     environment:
       PYTHONPATH: $PYTHONPATH:$SNAP/usr/lib/python3/dist-packages
     plugs:
         - network
         - network-bind
         - home
+        - dot-kube-config
 
 parts:
   spark:
@@ -103,12 +104,12 @@ parts:
             exit 1
         fi
         cd ..
-        mkdir -p $SNAPCRAFT_PRIME/bin
-        cp -r bin/* $SNAPCRAFT_PRIME/bin/
-        mkdir -p $SNAPCRAFT_PRIME/jars
-        cp -r jars/* $SNAPCRAFT_PRIME/jars/
-        mkdir -p $SNAPCRAFT_PRIME/python
-        cp -r python/* $SNAPCRAFT_PRIME/python/
+        mkdir -p $CRAFT_PART_INSTALL/bin
+        cp -r bin/* $CRAFT_PART_INSTALL/bin/
+        mkdir -p $CRAFT_PART_INSTALL/jars
+        cp -r jars/* $CRAFT_PART_INSTALL/jars/
+        mkdir -p $CRAFT_PART_INSTALL/python
+        cp -r python/* $CRAFT_PART_INSTALL/python/
     override-prime: |
         snapcraftctl prime
         rm -vf usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs
@@ -122,7 +123,7 @@ parts:
     source: helpers
     source-type: local
     override-build: |
-      target_dir="${SNAPCRAFT_PRIME}/ops"
+      target_dir="${CRAFT_PART_INSTALL}/ops"
       
       rm -rf "${target_dir}"
       mkdir -p "${target_dir}"
@@ -132,16 +133,18 @@ parts:
       chmod 755 "${target_dir}/spark-submit.py"
       cp spark-shell.py "${target_dir}/"
       chmod 755 "${target_dir}/spark-shell.py"
+      cp pyspark.py "${target_dir}/"
+      chmod 755 "${target_dir}/pyspark.py"
       cp utils.py "${target_dir}/"
       chmod 755 "${target_dir}/utils.py"
       cp constants.py "${target_dir}/"
       chmod 755 "${target_dir}/constants.py"
       
-      mkdir -p "$SNAPCRAFT_PRIME/conf"
-      cp spark-defaults.conf "$SNAPCRAFT_PRIME/conf/"
+      mkdir -p "$CRAFT_PART_INSTALL/conf"
+      cp spark-defaults.conf "$CRAFT_PART_INSTALL/conf/"
       
       curl -LO -s "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       chmod +x kubectl
-      cp kubectl ${SNAPCRAFT_PRIME}/
+      cp kubectl ${CRAFT_PART_INSTALL}/
       
       

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -84,7 +84,7 @@ test_pyspark() {
   echo "     return 1 if x ** 2 + y ** 2 <= 1 else 0" >> test-pyspark.py
   echo "count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)" >> test-pyspark.py
   echo "print (\"Pi is roughly %f\" % (4.0 * count / n))" >> test-pyspark.py
-  echo -e "$(cat test-pyspark.py | spark-client.pyspark --conf "spark.driver.host=${DRIVER_IP} --conf spark.executor.instances=4")" > pyspark.out
+  echo -e "$(cat test-pyspark.py | spark-client.pyspark --conf "spark.driver.host=${DRIVER_IP} --conf spark.executor.instances=2")" > pyspark.out
   cat pyspark.out
   pi=$(cat pyspark.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
   echo -e "Pyspark Pi Job Output: \n ${pi}"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -84,7 +84,8 @@ test_pyspark() {
   echo "     return 1 if x ** 2 + y ** 2 <= 1 else 0" >> test-pyspark.py
   echo "count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)" >> test-pyspark.py
   echo "print (\"Pi is roughly %f\" % (4.0 * count / n))" >> test-pyspark.py
-  echo -e "$(cat test-pyspark.py | spark-client.pyspark --conf "spark.driver.host=${DRIVER_IP}")" > pyspark.out
+  echo -e "$(cat test-pyspark.py | spark-client.pyspark --conf "spark.driver.host=${DRIVER_IP} --conf spark.executor.instances=4")" > pyspark.out
+  cat pyspark.out
   pi=$(cat pyspark.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-4)
   echo -e "Pyspark Pi Job Output: \n ${pi}"
   spark-client.setup-spark-k8s service-account-cleanup


### PR DESCRIPTION
Introducing wrapper for pyspark introduced issues.

1. Mixed mode exposes python version mismatch between snap (3.8) and rock (3.10) coming from core20 and core22 resp.
2. Moving the snap to core22 is not a trivial change
3. Found this bug, configuration "associated" with a service account can by mistake point to another service account which creates havoc during job submission and spark-shell and pyspark runs.
