### PR TITLE
Fixing CI token for PR on Spark update detection and for Github release publish.

### DIFF
--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -69,8 +69,8 @@ jobs:
           --title 'Update snap for new spark version' \
           --body 'Update client snap with new version of Apache Spark.' \
           --base main
-          --assignee team-reviewers, deusebio, taurus, abhishek-verma \
-          --reviewer team-reviewers, deusebio, taurus, abhishek-verma \
+          --assignee team-reviewers, deusebio, taurus-forever, averma-canonical \
+          --reviewer team-reviewers, deusebio, taurus-forever, averma-canonical \
           --label 'automated pr'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -65,23 +65,12 @@ jobs:
 
       - name: create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.SPARK_PKG_PUBLISH }}
-          commit-message: Publish snap for new spark version
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          branch: update-spark-snap
-          delete-branch: true
-          title: 'Update snap for new spark version'
-          body: |
-            Update client snap with new version of Apache Spark.
-          labels: |
-            automated pr
-          assignees: team-reviewers, deusebio, taurus, abhishek-verma
-          reviewers: team-reviewers, deusebio, taurus
-          team-reviewers: |
-            owners
-            maintainers
-          draft: false
+        run: gh pr create \
+          --title 'Update snap for new spark version' \
+          --body 'Update client snap with new version of Apache Spark.' \
+          --base main
+          --assignee team-reviewers, deusebio, taurus, abhishek-verma \
+          --reviewer team-reviewers, deusebio, taurus \
+          --label 'automated pr'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -70,7 +70,7 @@ jobs:
           --body 'Update client snap with new version of Apache Spark.' \
           --base main
           --assignee team-reviewers, deusebio, taurus, abhishek-verma \
-          --reviewer team-reviewers, deusebio, taurus \
+          --reviewer team-reviewers, deusebio, taurus, abhishek-verma \
           --label 'automated pr'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -52,6 +52,8 @@ jobs:
       - id: checkout
         name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH }}
       - id: record_spark_latest_version
         name: Record updated Spark version
         run: |

--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -66,11 +66,11 @@ jobs:
       - name: create pull request
         id: cpr
         run: gh pr create \
-          --title 'Update snap for new spark version' \
-          --body 'Update client snap with new version of Apache Spark.' \
-          --base main
+          --title "Update snap for new spark version" \
+          --body "Update client snap with new version of Apache Spark." \
+          --base main \
           --assignee team-reviewers, deusebio, taurus-forever, averma-canonical \
           --reviewer team-reviewers, deusebio, taurus-forever, averma-canonical \
-          --label 'automated pr'
+          --label "automated pr"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_spark_update_available.yaml
+++ b/.github/workflows/on_spark_update_available.yaml
@@ -5,8 +5,7 @@ env:
 
 on:
   schedule:
-    - cron: '30 10 * * *'
-
+    - cron: '00 16 * * *'
 
 jobs:
   check-spark:
@@ -53,24 +52,30 @@ jobs:
       - id: checkout
         name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ env.BRANCH }}
-      - name: Record the published Spark version in SPARK_VERSION file
-        uses: DamianReeves/write-file-action@master
-        with:
-          path: ./SPARK_VERSION
-          write-mode: overwrite
-          contents: |
-            ${{ needs.check-spark.outputs.version }}
-
+      - id: record_spark_latest_version
+        name: Record updated Spark version
+        run: |
+          git config user.email "abhishek.verma@canonical.com"
+          git config user.name "Abhishek Verma"
+          git checkout -b ${{ github.run_id }}-${{ github.run_attempt }}
+          echo -n ${{ needs.check-spark.outputs.version }} > ./SPARK_VERSION
+          git add ./SPARK_VERSION
+          git config author.name "GitHub <noreply@github.com>"
+          git config author.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          git commit -m "Update Spark Snap"
+          git push --set-upstream origin ${{ github.run_id }}-${{ github.run_attempt }}
       - name: create pull request
         id: cpr
-        run: gh pr create \
-          --title "Update snap for new spark version" \
-          --body "Update client snap with new version of Apache Spark." \
-          --base main \
-          --assignee team-reviewers, deusebio, taurus-forever, averma-canonical \
-          --reviewer team-reviewers, deusebio, taurus-forever, averma-canonical \
+        run: gh pr create 
+          --title "Update snap for new spark version" 
+          --body "Update client snap with new version of Apache Spark." 
+          --base main 
+          --assignee deusebio
+          --assignee taurus-forever
+          --assignee averma-canonical
+          --reviewer deusebio
+          --reviewer taurus-forever
+          --reviewer averma-canonical 
           --label "automated pr"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -2,7 +2,7 @@ name: Create a github release
 
 env:
   BRANCH: ${{ github.ref_name }}
-  SNAP_VERSION: 3.3.1
+  SNAP_VERSION: 3.3.2
   VERSION: 0.0.1
 
 on:

--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -72,15 +72,10 @@ jobs:
           echo $TAG
           echo $PROJECT_VERSION
           if [[ "$TAG" != "v$PROJECT_VERSION" ]]; then exit 1; fi
-#      - name: Release Notes
-#        uses: heinrichreimer/github-changelog-generator-action@v2.3
-#        with:
-#          token: ${{ secrets.SPARK_PKG_PUBLISH }}
-#          output: ".github/RELEASE-TEMPLATE.md"
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.SPARK_PKG_PUBLISH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body_path: ".github/RELEASE-TEMPLATE.md"
           files: |

--- a/helpers/spark-defaults.conf
+++ b/helpers/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.kubernetes.container.image=docker.io/dataplatformoci/spark:3.3.1
+spark.kubernetes.container.image=docker.io/dataplatformoci/spark:3.3.2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: spark-client
 base: core22
-version: '3.3.1'
+version: '3.3.2'
 summary: Client side scripts to submit Spark jobs to a cluster.
 description: |
   The spark-client snap includes the scripts spark-submit, spark-shell, pyspark and other tools for managing Apache Spark jobs.

--- a/spark_client/resources/conf/spark-defaults.conf
+++ b/spark_client/resources/conf/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.kubernetes.container.image=docker.io/dataplatformoci/spark:3.3.1
+spark.kubernetes.container.image=docker.io/dataplatformoci/spark:3.3.2

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -10,7 +10,7 @@ test_example_job() {
   KUBE_CONFIG=/home/${USER}/.kube/config
 
   K8S_MASTER_URL=k8s://$(kubectl --kubeconfig=${KUBE_CONFIG} config view -o jsonpath="{.clusters[0]['cluster.server']}")
-  SPARK_EXAMPLES_JAR_NAME='spark-examples_2.12-3.3.1.jar'
+  SPARK_EXAMPLES_JAR_NAME='spark-examples_2.12-3.3.2.jar'
 
   echo $K8S_MASTER_URL
 


### PR DESCRIPTION
New release of Spark is out (3.3.2). Our CI pipeline detected it but failed to create a PR for this due to bad token configuration.

With suggestions from Alex, sharing a fix for broken github token in CI for
- PR creation on Spark update detection
- Github artifacts release pipeline

Also, replacing third party action with github tooling for PR creation.

Adding Carl to the review as well for suggestions.