### PR TITLE
1035 driver host autodetect

### DIFF
--- a/spark_client/cli/pyspark.py
+++ b/spark_client/cli/pyspark.py
@@ -14,7 +14,6 @@ from spark_client.services import (
 from spark_client.utils import (
     add_logging_arguments,
     custom_parser,
-    get_driver_host_conf,
     parse_arguments_with,
 )
 
@@ -44,16 +43,8 @@ if __name__ == "__main__":
     if service_account is None:
         raise ValueError("Service account provided does not exist.")
 
-    extra_args_with_driver_host = extra_args
-
-    detected_driver_host_to_add = get_driver_host_conf()
-    if detected_driver_host_to_add:
-        extra_args_with_driver_host = extra_args_with_driver_host + [
-            f"--conf spark.driver.host={detected_driver_host_to_add}"
-        ]
-
     SparkInterface(
         service_account=service_account,
         kube_interface=kube_interface,
         defaults=defaults,
-    ).pyspark_shell(args.properties_file, extra_args_with_driver_host)
+    ).pyspark_shell(args.properties_file, extra_args)

--- a/spark_client/cli/pyspark.py
+++ b/spark_client/cli/pyspark.py
@@ -11,12 +11,11 @@ from spark_client.services import (
     KubeInterface,
     SparkInterface,
 )
-
 from spark_client.utils import (
     add_logging_arguments,
     custom_parser,
+    get_driver_host_conf,
     parse_arguments_with,
-    get_driver_host_conf
 )
 
 if __name__ == "__main__":
@@ -49,7 +48,9 @@ if __name__ == "__main__":
 
     detected_driver_host_to_add = get_driver_host_conf()
     if detected_driver_host_to_add:
-        extra_args_with_driver_host = extra_args_with_driver_host + [f"--conf spark.driver.host={detected_driver_host_to_add}"]
+        extra_args_with_driver_host = extra_args_with_driver_host + [
+            f"--conf spark.driver.host={detected_driver_host_to_add}"
+        ]
 
     SparkInterface(
         service_account=service_account,

--- a/spark_client/cli/spark-shell.py
+++ b/spark_client/cli/spark-shell.py
@@ -11,10 +11,12 @@ from spark_client.services import (
     KubeInterface,
     SparkInterface,
 )
+
 from spark_client.utils import (
     add_logging_arguments,
     custom_parser,
     parse_arguments_with,
+    get_driver_host_conf
 )
 
 if __name__ == "__main__":
@@ -43,8 +45,14 @@ if __name__ == "__main__":
     if service_account is None:
         raise ValueError("Service account provided does not exist.")
 
+    extra_args_with_driver_host = extra_args
+
+    detected_driver_host_to_add = get_driver_host_conf()
+    if detected_driver_host_to_add:
+        extra_args_with_driver_host = extra_args_with_driver_host + [f"--conf spark.driver.host={detected_driver_host_to_add}"]
+
     SparkInterface(
         service_account=service_account,
         kube_interface=kube_interface,
         defaults=defaults,
-    ).spark_shell(args.properties_file, extra_args)
+    ).spark_shell(args.properties_file, extra_args_with_driver_host)

--- a/spark_client/cli/spark-shell.py
+++ b/spark_client/cli/spark-shell.py
@@ -11,12 +11,11 @@ from spark_client.services import (
     KubeInterface,
     SparkInterface,
 )
-
 from spark_client.utils import (
     add_logging_arguments,
     custom_parser,
+    get_driver_host_conf,
     parse_arguments_with,
-    get_driver_host_conf
 )
 
 if __name__ == "__main__":
@@ -49,7 +48,9 @@ if __name__ == "__main__":
 
     detected_driver_host_to_add = get_driver_host_conf()
     if detected_driver_host_to_add:
-        extra_args_with_driver_host = extra_args_with_driver_host + [f"--conf spark.driver.host={detected_driver_host_to_add}"]
+        extra_args_with_driver_host = extra_args_with_driver_host + [
+            f"--conf spark.driver.host={detected_driver_host_to_add}"
+        ]
 
     SparkInterface(
         service_account=service_account,

--- a/spark_client/cli/spark-shell.py
+++ b/spark_client/cli/spark-shell.py
@@ -14,7 +14,6 @@ from spark_client.services import (
 from spark_client.utils import (
     add_logging_arguments,
     custom_parser,
-    get_driver_host_conf,
     parse_arguments_with,
 )
 
@@ -44,16 +43,8 @@ if __name__ == "__main__":
     if service_account is None:
         raise ValueError("Service account provided does not exist.")
 
-    extra_args_with_driver_host = extra_args
-
-    detected_driver_host_to_add = get_driver_host_conf()
-    if detected_driver_host_to_add:
-        extra_args_with_driver_host = extra_args_with_driver_host + [
-            f"--conf spark.driver.host={detected_driver_host_to_add}"
-        ]
-
     SparkInterface(
         service_account=service_account,
         kube_interface=kube_interface,
         defaults=defaults,
-    ).spark_shell(args.properties_file, extra_args_with_driver_host)
+    ).spark_shell(args.properties_file, extra_args)

--- a/spark_client/services.py
+++ b/spark_client/services.py
@@ -838,7 +838,9 @@ class SparkInterface(WithLogging):
                 "spark.driver.host" not in conf.props
                 and not self.check_driver_host_extra_conf()
             ):
-                raise ValueError("")
+                raise ValueError(
+                    "Please specify spark.driver.host configuration property"
+                )
 
             conf.write(t.file)
             t.flush()

--- a/spark_client/services.py
+++ b/spark_client/services.py
@@ -820,7 +820,9 @@ class SparkInterface(WithLogging):
             spark_driver_host = self.detect_host()
 
             conf = (
-                PropertyFile({"spark.driver.host": spark_driver_host}) if spark_driver_host else PropertyFile({})
+                PropertyFile({"spark.driver.host": spark_driver_host})
+                if spark_driver_host
+                else PropertyFile({})
                 + self._read_properties_file(self.defaults.static_conf_file)
                 + PropertyFile(
                     {
@@ -871,7 +873,9 @@ class SparkInterface(WithLogging):
             spark_driver_host = self.detect_host()
 
             conf = (
-                PropertyFile({"spark.driver.host": spark_driver_host}) if spark_driver_host else PropertyFile({})
+                PropertyFile({"spark.driver.host": spark_driver_host})
+                if spark_driver_host
+                else PropertyFile({})
                 + self._read_properties_file(self.defaults.static_conf_file)
                 + self.service_account.configurations
                 + self._read_properties_file(self.defaults.env_conf_file)

--- a/spark_client/services.py
+++ b/spark_client/services.py
@@ -820,15 +820,13 @@ class SparkInterface(WithLogging):
             spark_driver_host = self.detect_host()
 
             conf = (
-                self._read_properties_file(self.defaults.static_conf_file)
+                PropertyFile({"spark.driver.host": spark_driver_host}) if spark_driver_host else PropertyFile({})
+                + self._read_properties_file(self.defaults.static_conf_file)
                 + PropertyFile(
                     {
                         "spark.driver.extraJavaOptions": f"-Dscala.shell.histfile={self.defaults.scala_history_file}"
                     }
                 )
-                + PropertyFile({"spark.driver.host": spark_driver_host})
-                if spark_driver_host
-                else PropertyFile({})
                 + self.service_account.configurations
                 + self._read_properties_file(self.defaults.env_conf_file)
                 + self._read_properties_file(cli_property)
@@ -873,10 +871,8 @@ class SparkInterface(WithLogging):
             spark_driver_host = self.detect_host()
 
             conf = (
-                self._read_properties_file(self.defaults.static_conf_file)
-                + PropertyFile({"spark.driver.host": spark_driver_host})
-                if spark_driver_host
-                else PropertyFile({})
+                PropertyFile({"spark.driver.host": spark_driver_host}) if spark_driver_host else PropertyFile({})
+                + self._read_properties_file(self.defaults.static_conf_file)
                 + self.service_account.configurations
                 + self._read_properties_file(self.defaults.env_conf_file)
                 + self._read_properties_file(cli_property)

--- a/spark_client/utils.py
+++ b/spark_client/utils.py
@@ -2,10 +2,9 @@
 
 import errno
 import io
-import logging
 import os
-import subprocess
 import socket
+import subprocess
 from contextlib import contextmanager
 from copy import deepcopy as copy
 from functools import reduce
@@ -200,6 +199,7 @@ def parse_arguments_with(parsers=[], namespace=None):
         lambda x, f: f(x), parsers, argparse.ArgumentParser()
     ).parse_known_args(namespace=namespace)
 
+
 def add_conf_arguments(parser):
     """
     Add conf argument parsing to the existing parsing context
@@ -212,6 +212,7 @@ def add_conf_arguments(parser):
         type=str,
     )
     return parser
+
 
 def add_logging_arguments(parser):
     """
@@ -274,31 +275,44 @@ def add_deploy_arguments(parser):
     )
     return parser
 
-def get_driver_host_conf() -> str:
-    args_including_conf, remaining_args = parse_arguments_with([add_logging_arguments, custom_parser, add_conf_arguments])
+
+def get_driver_host_conf() -> Any:
+    args_including_conf, remaining_args = parse_arguments_with(
+        [add_logging_arguments, custom_parser, add_conf_arguments]
+    )
 
     if args_including_conf.conf:
-        conf_args = dict(conf_entry.split('=',1) for conf_entry in args_including_conf.conf)
+        conf_args = dict(
+            conf_entry.split("=", 1) for conf_entry in args_including_conf.conf
+        )
     else:
         conf_args = {}
 
     if "spark.driver.host" not in conf_args:
         spark_driver_host = detect_host()
         if spark_driver_host is None:
-            raise ValueError("Please provide spark.driver.host spark configuration option to proceed.....")
+            raise ValueError(
+                "Please provide spark.driver.host spark configuration option to proceed....."
+            )
         return spark_driver_host
     else:
         return None
 
-def detect_host() -> str:
+
+def detect_host() -> Any:
     try:
         host_py = socket.gethostbyname(socket.gethostname()).strip()
     except Exception:
         return None
 
-
     try:
-        host_bash = subprocess.check_output("hostname -I | cut -d' ' -f1", shell=True, stderr=None).decode("utf-8").strip()
+        host_bash = (
+            subprocess.check_output(
+                "hostname -I | cut -d' ' -f1", shell=True, stderr=None
+            )
+            .decode("utf-8")
+            .strip()
+        )
     except Exception:
         return None
 
@@ -306,6 +320,3 @@ def detect_host() -> str:
         return host_py
     else:
         return None
-
-
-

--- a/spark_client/utils.py
+++ b/spark_client/utils.py
@@ -3,7 +3,6 @@
 import errno
 import io
 import os
-import socket
 import subprocess
 from contextlib import contextmanager
 from copy import deepcopy as copy
@@ -274,49 +273,3 @@ def add_deploy_arguments(parser):
         help="Deployment mode for job submission. Default is 'client'.",
     )
     return parser
-
-
-def get_driver_host_conf() -> Any:
-    args_including_conf, remaining_args = parse_arguments_with(
-        [add_logging_arguments, custom_parser, add_conf_arguments]
-    )
-
-    if args_including_conf.conf:
-        conf_args = dict(
-            conf_entry.split("=", 1) for conf_entry in args_including_conf.conf
-        )
-    else:
-        conf_args = {}
-
-    if "spark.driver.host" not in conf_args:
-        spark_driver_host = detect_host()
-        if spark_driver_host is None:
-            raise ValueError(
-                "Please provide spark.driver.host spark configuration option to proceed....."
-            )
-        return spark_driver_host
-    else:
-        return None
-
-
-def detect_host() -> Any:
-    try:
-        host_py = socket.gethostbyname(socket.gethostname()).strip()
-    except Exception:
-        return None
-
-    try:
-        host_bash = (
-            subprocess.check_output(
-                "hostname -I | cut -d' ' -f1", shell=True, stderr=None
-            )
-            .decode("utf-8")
-            .strip()
-        )
-    except Exception:
-        return None
-
-    if host_py == host_bash:
-        return host_py
-    else:
-        return None

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -63,15 +63,13 @@ test_example_job() {
 test_spark_shell() {
   spark-client.service-account-registry create --username=ie-test
 
-  export DRIVER_IP=$(hostname -I | cut -d " " -f 1)
-
   echo "import scala.math.random" > test-spark-shell.scala
   echo "val slices = 10" >> test-spark-shell.scala
   echo "val n = math.min(100000L * slices, Int.MaxValue).toInt" >> test-spark-shell.scala
   echo "val count = spark.sparkContext.parallelize(1 until n, slices).map { i => val x = random * 2 - 1; val y = random * 2 - 1;  if (x*x + y*y <= 1) 1 else 0;}.reduce(_ + _)" >> test-spark-shell.scala
   echo "println(s\"Pi is roughly \${4.0 * count / (n - 1)}\")" >> test-spark-shell.scala
   echo "System.exit(0)" >> test-spark-shell.scala
-  echo -e "$(cat test-spark-shell.scala | spark-client.spark-shell --username=ie-test --conf "spark.driver.host=${DRIVER_IP}")" > spark-shell.out
+  echo -e "$(cat test-spark-shell.scala | spark-client.spark-shell --username=ie-test)" > spark-shell.out
   pi=$(cat spark-shell.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-3)
   echo -e "Spark-shell Pi Job Output: \n ${pi}"
   spark-client.service-account-registry delete --username=ie-test
@@ -83,8 +81,6 @@ test_spark_shell() {
 
 test_pyspark() {
   spark-client.service-account-registry create --username=ie-test
-
-  export DRIVER_IP=$(hostname -I | cut -d " " -f 1)
 
   echo "import sys" > test-pyspark.py
   echo "from random import random" >> test-pyspark.py
@@ -101,7 +97,7 @@ test_pyspark() {
   echo "     return x * x + y * y < 1 " >> test-pyspark.py
   echo "count = spark.sparkContext.parallelize(range(n), partitions).filter(f).count()" >> test-pyspark.py
   echo "print (\"Pi is roughly %f\" % (4.0 * count / n))" >> test-pyspark.py
-  echo -e "$(cat test-pyspark.py | spark-client.pyspark --username=ie-test --conf "spark.driver.host=${DRIVER_IP} --conf spark.executor.instances=2")" > pyspark.out
+  echo -e "$(cat test-pyspark.py | spark-client.pyspark --username=ie-test --conf spark.executor.instances=2)" > pyspark.out
   cat pyspark.out
   pi=$(cat pyspark.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-3)
   echo -e "Pyspark Pi Job Output: \n ${pi}"

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ all_path = {[vars]src_path} {[vars]tst_path}
 [testenv]
 allowlist_externals = poetry
                       sg
-whitelist_externals = poetry
-                      sg
 setenv =
   PYTHONPATH = {toxinidir}:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace


### PR DESCRIPTION
Currently spark.driver.host config option has to be supplied explicitly by the user. 

This change is to choose the IP for the user when we are reasonably sure.
i.e. if output of socket.gethostbyname(socket.gethostname()) in python and hostname -I first entry point to the same ip.