### PR TITLE
Adding 2 hr timeout for integration tests which can be unstable as Spark versions change.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
 
   test:
     name: Test Snap
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     needs:
       - check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
   test:
     name: Test Snap
-    timeout-minutes: 120
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs:
       - check


### PR DESCRIPTION
…as requested in DPE-1326