### PR TITLE
Fixing bugs 1906, 1907, 1908 - regressions caused when porting to lightkube implementation

### DIFF
--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -3,7 +3,7 @@ name: Create a github release
 env:
   BRANCH: ${{ github.ref_name }}
   SNAP_VERSION: 3.3.2
-  VERSION: 0.0.6
+  VERSION: 0.0.8
 
 on:
   push:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ follow_imports = "silent"
 
 [tool.poetry]
 name = "spark-client"
-version = "0.0.6"
+version = "0.0.8"
 description = "This project allow you to create a SNAP for interacting with a K8s cluster to submit Spark jobs or run spark shells interactively"
 authors = [
     "Abhishek Verma <abhishek.verma@canonical.com>",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
   service-account-registry:
     command: ops/cli/service_account_registry.py
     environment:
-      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/python
+      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       OPS_ROOT: ${SNAP}/ops
     plugs:
         - network
@@ -31,7 +31,7 @@ apps:
   spark-submit:
     command: ops/cli/spark_submit.py
     environment:
-      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/python
+      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       OPS_ROOT: ${SNAP}/ops
     plugs:
         - network
@@ -40,7 +40,7 @@ apps:
   spark-shell:
     command: ops/cli/spark_shell.py
     environment:
-      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/python
+      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
     plugs:
         - network
         - network-bind
@@ -49,7 +49,7 @@ apps:
   pyspark:
     command: ops/cli/pyspark.py
     environment:
-      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/python
+      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
     plugs:
         - network
         - network-bind
@@ -71,24 +71,24 @@ parts:
         SPARK_HADOOP_VERSION='3'
         AWS_JAVA_SDK_BUNDLE_VERSION='1.11.874'
         HADOOP_AWS_VERSION='3.2.2'
-        SPARK_VERSION=$(curl --silent https://downloads.apache.org/spark/ | grep "spark-" | cut -d'>' -f3 | cut -d'/' -f1  | sort | tail -n 1)
-        STATUSCODE=$(curl --silent --head "https://downloads.apache.org/spark/${SPARK_VERSION}/${SPARK_VERSION}-bin-hadoop3.tgz" | head -n 1 | cut -d' ' -f2)
+        SPARK_VERSION=$(cat $CRAFT_PROJECT_DIR/SPARK_VERSION | tr -d '\n')
+        STATUSCODE=$(curl --silent --head "https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz" | head -n 1 | cut -d' ' -f2)
         if  [[ ${STATUSCODE} -ne 200 ]]
           then
-            echo "ERROR: Latest available Spark version ${SPARK_VERSION} does not have a downloadable binary! Exiting...."
+            echo "ERROR: Latest available Spark version spark-${SPARK_VERSION} does not have a downloadable binary! Exiting...."
             exit 1
         fi
-        echo "Downloading latest available Spark version ${SPARK_VERSION}."
-        wget "https://downloads.apache.org/spark/${SPARK_VERSION}/${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz"
-        wget "https://downloads.apache.org/spark/${SPARK_VERSION}/${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz.sha512"
-        sha512sum --check "${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz.sha512"
+        echo "Downloading latest available Spark version spark-${SPARK_VERSION}."
+        wget "https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz"
+        wget "https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz.sha512"
+        sha512sum --check "spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz.sha512"
         if  [[ $? -ne 0 ]]
           then
-            echo "DOWNLOAD ERROR: Latest available Spark version ${SPARK_VERSION} could not be downloaded properly! Exiting...."
+            echo "DOWNLOAD ERROR: Latest available Spark version spark-${SPARK_VERSION} could not be downloaded properly! Exiting...."
             exit 1
         fi
-        tar -zxf "${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz"
-        cd "${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}/jars"
+        tar -zxf "spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz"
+        cd "spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}/jars"
         wget "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_JAVA_SDK_BUNDLE_VERSION}/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE_VERSION}.jar"
         wget "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_JAVA_SDK_BUNDLE_VERSION}/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE_VERSION}.jar.sha1"        
         echo "`cat aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE_VERSION}.jar.sha1`  aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE_VERSION}.jar" | sha1sum --check

--- a/spark_client/cli/service_account_registry.py
+++ b/spark_client/cli/service_account_registry.py
@@ -188,6 +188,4 @@ if __name__ == "__main__":
 
     elif args.action == Actions.LIST:
         for service_account in registry.all():
-            print(
-                str.expandtabs(f"{service_account.id}\t{service_account.primary}")
-            )
+            print(str.expandtabs(f"{service_account.id}\t{service_account.primary}"))

--- a/spark_client/cli/service_account_registry.py
+++ b/spark_client/cli/service_account_registry.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 
     elif args.action == Actions.DELETE:
         user_id = build_service_account_from_args(args).id
-        logging.info(user_id)
+        print(user_id)
         registry.delete(user_id)
 
     elif args.action == Actions.ADD_CONFIG:
@@ -170,7 +170,7 @@ if __name__ == "__main__":
         if maybe_service_account is None:
             raise NoAccountFound(input_service_account.id)
 
-        maybe_service_account.configurations.log(logging.info)
+        maybe_service_account.configurations.log(print)
 
     elif args.action == Actions.CLEAR_CONFIG:
         registry.set_configurations(
@@ -184,10 +184,10 @@ if __name__ == "__main__":
             raise NoAccountFound()
 
         # maybe_service_account.configurations.log(logging.info)
-        logging.info(maybe_service_account.id)
+        print(maybe_service_account.id)
 
     elif args.action == Actions.LIST:
         for service_account in registry.all():
-            logging.info(
+            print(
                 str.expandtabs(f"{service_account.id}\t{service_account.primary}")
             )

--- a/spark_client/services.py
+++ b/spark_client/services.py
@@ -320,7 +320,7 @@ class LightKube(AbstractKubeInterface):
                 labels_to_pass[k] = v
 
         if not namespace:
-            namespace = "default"
+            namespace = "*"
 
         with io.StringIO() as buffer:
             codecs.dump_all_yaml(


### PR DESCRIPTION
After porting to lightkube some regressions were found, mainly printing of user relevant info in the cli tool as well as listing all service accounts which is a base case for many other operations.

Also, avoiding fetching latest spark version all the time. Instead always work with spark version approved as present in SPARK_VERSION file in the repo.

spark-client version 0.0.7 has already been used and was the one with botched lightkube implementation. Hence using tag 0.0.8 for the spark-client version.
