### PR TITLE
[DPE-2321] Documentation for AWS EKS

### DIFF
--- a/docs/how-to/h-deploy-spark-history-server.md
+++ b/docs/how-to/h-deploy-spark-history-server.md
@@ -9,18 +9,9 @@ Within the Charmed Spark solution, its deployment, configuration and operation i
 Since Spark History server will be managed by Juju, make sure that:
 * you have a Juju client (e.g. via a [SNAP](https://snapcraft.io/juju)) installed in your local machine  
 * you are able to connect to a juju controller running on K8s.
-* you have read-write permissions (therefore you have a access key and access secret) to a S3-compatible object storage (e.g. MinIO)
+* you have read-write permissions (therefore you have an access key, access secret and the s3 endpoint) to a S3-compatible object storage 
 
-To see how to setup a Juju controller on K8s and the juju client, you can refer to existing tutorials and documentation, e.g. [here](https://juju.is/docs/olm/get-started-with-juju).
-
-To see how to setup MinIO on top of MicroK8s, please refer to [here](https://microk8s.io/docs/addon-minio). If you have a MicroK8s MinIO plugin enabled, use the following commands to 
-obtain the access key, the access secret and the MinIO endpoint:
-
-* *access key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d`
-* *secret key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d`
-* *MinIO endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
-
-For other backends other than MinIO and microk8s (e.g. Ceph, AWS S3, Charmed Kubernetes, EKS, GKE, etc), please refer to the documentation or your admin to find out these information.
+To see how to setup a Juju controller on K8s and the juju client, you can refer to existing tutorials and documentation, e.g. [here](https://juju.is/docs/olm/get-started-with-juju) for MicroK8s and [here](https://juju.is/docs/juju/amazon-elastic-kubernetes-service-(amazon-eks)) for AWS EKS. Also refer to the [How-To Setup K8s Cluster]() userguide to install S3-compatible object storage on MicroK8s (MinIO) or EKS (AWS S3). For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to the documentation or your admin.
 
 ### Preparation
 

--- a/docs/how-to/h-deploy-spark-history-server.md
+++ b/docs/how-to/h-deploy-spark-history-server.md
@@ -124,7 +124,7 @@ and relate with the Spark History server charm
 juju relate traefik-k8s spark-history-server-k8s
 ```
 
-After the charms to settle down into `idle/active` states, fetch the URL of the Spark History server with 
+After the charms settle down into `idle/active` states, fetch the URL of the Spark History server with 
 
 ```bash
 juju run-action traefik-k8s/0 show-proxied-endpoints --wait

--- a/docs/how-to/h-deploy-spark-history.md
+++ b/docs/how-to/h-deploy-spark-history.md
@@ -11,7 +11,7 @@ Since Spark History server will be managed by Juju, make sure that:
 * you are able to connect to a juju controller running on K8s.
 * you have read-write permissions (therefore you have an access key, access secret and the s3 endpoint) to a S3-compatible object storage 
 
-To see how to setup a Juju controller on K8s and the juju client, you can refer to existing tutorials and documentation, e.g. [here](https://juju.is/docs/olm/get-started-with-juju) for MicroK8s and [here](https://juju.is/docs/juju/amazon-elastic-kubernetes-service-(amazon-eks)) for AWS EKS. Also refer to the [How-To Setup K8s Cluster]() userguide to install S3-compatible object storage on MicroK8s (MinIO) or EKS (AWS S3). For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to the documentation or your admin.
+To see how to setup a Juju controller on K8s and the juju client, you can refer to existing tutorials and documentation, e.g. [here](https://juju.is/docs/olm/get-started-with-juju) for MicroK8s and [here](https://juju.is/docs/juju/amazon-elastic-kubernetes-service-(amazon-eks)) for AWS EKS. Also refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) userguide to install S3-compatible object storage on MicroK8s (MinIO) or EKS (AWS S3). For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to the documentation or your admin.
 
 ### Preparation
 
@@ -165,4 +165,3 @@ $ spark-client.spark-submit --username <USER> --namespace <NAMESPACE> --class ..
 
 > Note that if you only want to store logs for some jobs, configuration files could also be provided directly to the `spark-client.spark-submit` command via the `--properties-file` argument. 
 > Please refer to the dedicated documentation for more information about [managing service account](/t/spark-client-snap-how-to-manage-spark-accounts/8959) and [running Spark jobs](/t/spark-client-snap-tutorial-spark-submit/8953) using the `spark-client` tool.
-

--- a/docs/how-to/h-setup-k8s.md
+++ b/docs/how-to/h-setup-k8s.md
@@ -1,0 +1,163 @@
+## How to setup a K8s cluster for Spark
+
+The Charmed Spark solution runs on top of a K8s distribution. We recommend you to use version 1.27. There are multiple ways that a K8s cluster can be deployed. Here below we summarize how to setup on K8s on the distributions that we currently support: 
+
+* MicroK8s
+* AWS EKS
+
+The how-to guide belows shows you how to setup all of the services used by Charmed Spark. It may be that given your use-case some of them may not be needed though.
+
+### MicroK8s
+
+[Microk8s](https://microk8s.io/) is the mightiest tiny Kubernetes distribution around. It can easily installed locally via SNAPs
+
+```bash
+sudo snap install microk8s --classic
+```
+
+When installing Microk8s, it is recommended to configure MicroK8s in a way, so that there exists a user that has admin rights on the cluster. 
+
+```bash 
+sudo snap alias microk8s.kubectl kubectl
+sudo usermod -a -G microk8s ${USER}
+mkdir -p ~/.kube
+sudo chown -f -R ${USER} ~/.kube
+```
+
+To make these changes effective, you can either open a new shell (or log in, log out) or use `newgrp microk8s` 
+
+Make sure that the MicroK8s cluster is now up and running:
+
+```bash
+microk8s status --wait-ready
+```
+
+Export the Kubernetes config file associated with admin rights and store it in the $KUBECONFIG file, e.g. `~/.kube/config`: 
+
+```bash 
+export KUBECONFIG=path/to/file # Usually ~/.kube/config
+microk8s config | tee ${KUBECONFIG}
+```
+
+Enable the K8s features required by the Spark Client Snap 
+
+```
+microk8s.enable dns rbac storage hostpath-storage
+```
+
+#### S3 Storage
+
+Enable the MinIO storage if you want to store Spark Jobs logs in a S3 compatible object storage to be then exposed via Charmed Spark History Server.
+
+```
+microk8s.enable minio
+```
+
+Refer [here](https://microk8s.io/docs/addon-minio) for more information how to customize your MinIO Microk8s deployment.
+
+Use the following commands to obtain the access key, the access secret and the MinIO endpoint:
+
+* *access key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d`
+* *secret key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d`
+* *MinIO endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
+
+#### External LoadBalancer
+
+Enable external loadbalancer if you want to expose the Spark History Server UI via a Traefik ingress
+
+```
+IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+microk8s enable metallb:$IPADDR-$IPADDR
+```
+
+The MicroK8s cluster is now ready to be used. 
+
+
+### AWS EKS
+
+In order to deploy an EKS cluster, make sure that you have working CLI tools properly installed on your edge machine:
+
+* [AWS CLI](https://aws.amazon.com/cli/) correctly setup to use a properly configured service account (refer to [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) for configuration and [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html) for authentication). Once the AWS CLI is configured, make sure that it works properly by testing the authentication call through the following command:
+```bash 
+aws sts get-identity-caller
+```
+
+* [eksctl](https://eksctl.io/) installed and configure (refer to the [README.md] file for more information on how to install it)
+
+Make also sure that your service account (configured in AWS) has the right permission to create and manage EKS clusters. In general, we recommend the use of profiles when having multiple accounts.
+
+#### Creating the cluster
+
+Create a YAML file with the following content 
+
+```yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+    name: spark-cluster
+    region: <AWS_REGION_NAME>
+    version: "1.27"
+iam:
+  withOIDC: true
+
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
+
+nodeGroups:
+    - name: ng-1
+      minSize: 3
+      maxSize: 5
+      iam:
+        attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      instancesDistribution:
+        maxPrice: 0.15
+        instanceTypes: ["m5.xlarge", "m5.large"] # At least two instance types should be specified
+        onDemandBaseCapacity: 0
+        onDemandPercentageAboveBaseCapacity: 50
+        spotInstancePools: 2
+```
+
+Feel free to replace the ```<AWS_REGION_NAME>``` with the AWS region of your choice, and custom further the above YAML based on your needs and policies in place. 
+
+You can then create the EKS via CLI
+
+```bash
+eksctl create cluster -f cluster.yaml
+```
+
+The EKS cluster creation process may take several minutes. The cluster creation process should already update the `KUBECONFIG` file with the new cluster information. By default, `eksctl` creates a user that generate new access token on the fly via the `aws` CLI. However, this conflicts with the `spark-client` snap that is strictly confined and does not have access to the `aws` command. Therefore, we recommend you to manually retrieve a token, i.e.
+
+```bash 
+aws eks get-token --region <AWS_REGION_NAME> --cluster-name spark-cluster --output json
+```
+
+and paste the token in the KUBECONFIG file
+
+```yaml
+users:
+- name: eks-created-username
+  user:
+    token: <AWS_TOKEN>
+```
+
+The EKS cluster is now ready to be used. 
+
+#### S3 Storage
+
+Create a new bucket in the AWS S3 storage if you want to store Spark Jobs logs to be then exposed via Charmed Spark History Server.
+
+Create a new bucket via AWS CLI 
+
+```bash 
+aws s3api create-bucket --bucket <BUCKET_NAME> --region <AWS_REGION_NAME>
+```
+
+Use the access key and the access secret of your service account, also used for authenticating with the AWS CLI profile. The endpoint of the bucket is `https://s3.<AWS_REGION_NAME>.amazonaws.com`.

--- a/docs/how-to/h-setup-k8s.md
+++ b/docs/how-to/h-setup-k8s.md
@@ -1,6 +1,6 @@
 ## How to setup a K8s cluster for Spark
 
-The Charmed Spark solution runs on top of a K8s distribution. We recommend you to use version 1.27. There are multiple ways that a K8s cluster can be deployed. Here below we summarize how to setup on K8s on the distributions that we currently support: 
+The Charmed Spark solution runs on top of a K8s distribution. We recommend you to use version the latest stable version, but at least version 1.26. There are multiple ways that a K8s cluster can be deployed. Here below we summarize how to setup on K8s on the distributions that we currently support: 
 
 * MicroK8s
 * AWS EKS
@@ -88,6 +88,7 @@ Make also sure that your service account (configured in AWS) has the right permi
 
 #### Creating the cluster
 
+An EKS cluster can be created using `eksctl`, the AWS Management Console, or the AWS CLI. In the following we will use `eksctl`.
 Create a YAML file with the following content 
 
 ```yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+# Charmed Spark Documentation
+
 The Spark Client Snap is a utility client application that allows for running Apache Spark on Kubernetes in a simple and seamless manner. All necessary components are packed in a single confined [Snap](https://snapcraft.io/) package:
 
 * [Apache Spark](https://spark.apache.org/downloads.html) (binaries, executables and libraries)
@@ -33,7 +35,7 @@ Spark Client Snap is an official distribution of Apache Spark. It’s an open-so
 
 | Level | Path                           | Navlink                                                                                                              |
 |-------|--------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| 1     | overview                       | [Overview](/t/spark-client-snap-documentation/8963)                                                                                                  | 
+| 1     | overview                       | [Overview](/t/spark-client-snap-documentation/8963)                                                                  | 
 | 1     | tutorial                       | [Tutorial]()                                                                                                         |
 | 2     | t-overview                     | [1. Introduction](/t/spark-client-snap-tutorial/8957)                                                                |
 | 2     | t-setup-environment            | [2. Set up the environment](/t/spark-client-snap-tutorial-setup-environment/8951)                                    |
@@ -42,11 +44,12 @@ Spark Client Snap is an official distribution of Apache Spark. It’s an open-so
 | 2     | t-spark-shells                 | [5. Use interactive shells](/t/spark-client-snap-tutorial-interactive-mode/8954)                                     |
 | 2     | t-tips-and-tricks              | [6. Tips and Tricks](/t/spark-client-snap-tutorial-common-gotchas/8955)                                              |
 | 1     | how-to                         | [How To]()                                                                                                           |
+| 2     | h-setup-k8s                    | [Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618)                           |
 | 2     | h-manage-service-accounts      | [Manage Service Accounts](/t/spark-client-snap-how-to-manage-spark-accounts/8959)                                    |
 | 2     | h-use-spark-client-from-python | [Use the Spark Client Python API](/t/spark-client-snap-how-to-python-api/8958)                                       |
-| 2     | h-run-on-charmed-k8s           | [Run on Charmed Kubernetes](/t/spark-client-snap-how-to-run-on-charmed-kubernetes/8960)                              |
 | 2     | h-run-on-k8s-pod               | [Run on K8s pods](/t/spark-client-snap-how-to-run-on-k8s-in-a-pod/8961)                                              |
-| 2     | h-spark-streaming               | [Run Spark Streaming Jobs](/t/charmed-spark-how-to-run-a-spark-streaming-job/10880)                                              |
+| 2     | h-deploy-spark-history         | [Deploy Spark History Server](/t/charmed-spark-k8s-documentation-how-to-deploy-spark-history-server/10979)           |
+| 2     | h-spark-streaming              | [Run Spark Streaming Jobs](/t/charmed-spark-how-to-run-a-spark-streaming-job/10880)                                  |
 | 1     | reference                      | [Reference]()                                                                                                        |
 | 2     | r-requirements                 | [Requirements](/t/spark-client-snap-reference-requirements/8962)                                                     |
 | 1     | explanation                    | [Explanation]()                                                                                                      |

--- a/docs/tutorial/t-overview.md
+++ b/docs/tutorial/t-overview.md
@@ -1,4 +1,4 @@
-# `spark-client` Snap tutorial
+# Charmed Spark Tutorial 
 
 The `spark-client` Snap package delivers Spark utility client applications, that allow for simple and seamless usage of Apache Spark on Kubernetes.
 

--- a/docs/tutorial/t-setup-environment.md
+++ b/docs/tutorial/t-setup-environment.md
@@ -1,7 +1,9 @@
 ## Setup Kubernetes and Spark Client Snap
 
-In order to be able to work with Kubernetes,  first we first to set up a Kubernetes cluster. In this tutorial we use [MicroK8s](https://microk8s.io/), 
-which is the simplest production-grade conformant K8s.
+In order to be able to work with Kubernetes, we first need to set up a Kubernetes cluster. 
+
+In this tutorial we use [MicroK8s](https://microk8s.io/), which is the simplest production-grade conformant K8s.
+If you would like to run this tutorial on other K8s installation, please refer to the "How-to setup on K8s" user guide. 
 
 ### Setup MicroK8s
 

--- a/docs/tutorial/t-setup-environment.md
+++ b/docs/tutorial/t-setup-environment.md
@@ -3,7 +3,7 @@
 In order to be able to work with Kubernetes, we first need to set up a Kubernetes cluster. 
 
 In this tutorial we use [MicroK8s](https://microk8s.io/), which is the simplest production-grade conformant K8s.
-If you would like to run this tutorial on other K8s installation, please refer to the "How-to setup on K8s" user guide. 
+If you would like to run this tutorial on other K8s installation, please refer to the [How-to setup environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) user guide. 
 
 ### Setup MicroK8s
 


### PR DESCRIPTION
After testing the Charmed Spark solution on EKS, I have written up the documentation about how to setup an EKS cluster and configure the environment to make it work with Charmed Spark. 

The only part I was not able to test was enabling TLS encrypted connection using Traefik and Route53, because of [this](https://github.com/canonical/traefik-k8s-operator/issues/214) issue, but I don't think it is blocking for merging this PR.

Once the issue is resolved, I will re-test the spark-history <> traefik <> route53 integration, but I don't think the documentation would need an update.  