### PR TITLE
[DPE-3253] Upgrade spark8t to 0.0.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ parts:
   spark8t:
     plugin: python
     python-packages:
-        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.2/spark8t-0.0.2-py3-none-any.whl
+        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.3/spark8t-0.0.3-py3-none-any.whl
     source: .
     build-packages:
         - python3


### PR DESCRIPTION
Title says it all. The reason is that the new Spark tutorial is based on some of the changes we have recently done in the `spark8t` library.