### PR TITLE
[DPE-3552] Add self signed certificate handling to the Spark-Client on spark-submit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
   test:
     name: Test Snap
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: build
     steps:
       - name: Download snap file

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         id: microceph
         uses: canonical/microceph-action@v0.2
         with:
-          channel: 'latest/edge'
+          channel: 'latest/stable'
           accesskey: 'accesskey'
           secretkey: 'secretkey'
           bucket: 'testbucket'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Setup MicroK8s
         run: |
           make microk8s
+          
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
 
       - name: Run Integration Tests
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,9 @@ jobs:
         run: |
           make microk8s
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
       - name: Run Integration Tests
         env:
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Setup microceph
         id: microceph
-        if: ${{ matrix.tox-environments }} == 'integration-tls'
         uses: canonical/microceph-action@v0.2
         with:
           channel: 'latest/edge'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Setup MicroK8s
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,23 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Setup microceph
+        id: microceph
+        if: ${{ matrix.tox-environments }} == 'integration-tls'
+        uses: canonical/microceph-action@v0.2
+        with:
+          channel: 'latest/edge'
+          accesskey: 'accesskey'
+          secretkey: 'secretkey'
+          bucket: 'testbucket'
+          osdsize: '3G'
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
       - name: Setup MicroK8s
         run: |
           make microk8s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,9 +69,6 @@ jobs:
         run: |
           make microk8s
 
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-
       - name: Run Integration Tests
         env:
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,8 @@ jobs:
         run: |
           make microk8s
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
 
       - name: Run Integration Tests
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,6 @@ jobs:
       - name: Setup MicroK8s
         run: |
           make microk8s
-          
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
 
       - name: Run Integration Tests
         env:

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,7 +10,10 @@ export DATA="${SNAP_COMMON}"/var/lib/$COMPONENT
 mkdir -p $LOGS
 mkdir -p $DATA
 
-cp -r $SNAP/etc/ ${SNAP_DATA}
+cp -r $SNAP/etc ${SNAP_DATA}
+# copy original cacerts in SNAP_DATA
+cp $SNAP/etc/cacerts ${SNAP_DATA}/etc/ssl/certs/java/
 
 chmod -R 775 "${SNAP_DATA}"/*
 chmod -R 775 "${SNAP_COMMON}"/*
+chmod -R 777 "${SNAP_DATA}"/etc/ssl/certs/java/cacerts

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+echo "Alias $1"
+echo "Certificate path $2"
+
+${SNAP}/usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
+echo "Certificate imported!"

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -14,7 +14,7 @@ then
     
     echo "List inserted cert:"
     ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -alias "$1"  -storepass changeit
-
+    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -storepass changeit | wc -l
 
 else
     echo "Missing alias or path!"

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 alias=$1
 path=$2
@@ -8,15 +7,8 @@ if [[ $alias && $path ]]
 then
     echo "Alias $1"
     echo "Certificate path $2"
-
     ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
     echo "Certificate imported!"
-    
-    echo "List inserted cert:"
-    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -alias "$1"  -storepass changeit
-    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -storepass changeit | wc -l
-
 else
-    echo "Missing alias or path!"
+    echo "Missing alias or certificate path."
 fi
-set +x

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -9,7 +9,7 @@ then
     echo "Alias $1"
     echo "Certificate path $2"
 
-    ${SNAP}/usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
+    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
     echo "Certificate imported!"
 else
     echo "Missing alias or path!"

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 set -e
 
-echo "Alias $1"
-echo "Certificate path $2"
+alias=$1
+path=$2
 
-${SNAP}/usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
-echo "Certificate imported!"
+if [[ $alias && $path ]]
+then
+    echo "Alias $1"
+    echo "Certificate path $2"
+
+    ${SNAP}/usr/lib/jvm/java-11-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
+    echo "Certificate imported!"
+else
+    echo "Missing alias or path!"
+fi

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -x
 
 alias=$1
 path=$2
@@ -11,6 +11,12 @@ then
 
     ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -import -v -alias "$1" -file "$2"  -storepass changeit -noprompt -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts
     echo "Certificate imported!"
+    
+    echo "List inserted cert:"
+    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -alias "$1"
+
+
 else
     echo "Missing alias or path!"
 fi
+set +x

--- a/snap/local/etc/spark8t/bin/import-certificate.sh
+++ b/snap/local/etc/spark8t/bin/import-certificate.sh
@@ -13,7 +13,7 @@ then
     echo "Certificate imported!"
     
     echo "List inserted cert:"
-    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -alias "$1"
+    ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64/bin/keytool -list -keystore ${SNAP_DATA}/etc/ssl/certs/java/cacerts -alias "$1"  -storepass changeit
 
 
 else

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,9 +36,11 @@ apps:
         - home
         - dot-kube-config
   spark-submit:
-    command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
+    command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py $SPARK8T_EXTRA_CONF
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
+      SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - home
@@ -74,11 +76,26 @@ apps:
         - home
         - dot-kube-config
 
+  import-certificate:
+    command: etc/spark8t/bin/import-certificate.sh
+    environment:
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
+    plugs:
+        - network
+        - network-bind
+        - home
+        - dot-kube-config
+
 parts:
 
   spark8t-conf:
     plugin: dump
     source: snap/local
+    override-prime: |
+      craftctl default
+      chmod +x etc/spark8t/bin/import-certificate.sh
+      mkdir -p home/ubuntu
+      chmod u+x home/ubuntu/
 
   spark8t:
     plugin: python
@@ -136,8 +153,9 @@ parts:
 
     override-prime: |
         snapcraftctl prime
-        rm -vf usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs
-
+        rm -vf usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs 
+        # move base certs data
+        mv etc/ssl/certs/java/cacerts etc/cacerts
   kubectl:
     plugin: nil
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,7 +154,7 @@ parts:
 
     override-prime: |
         snapcraftctl prime
-        rm -vf usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs 
+        rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs 
         # move base certs data
         mv etc/ssl/certs/java/cacerts etc/cacerts
   kubectl:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
-      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.debug=all -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,7 +102,7 @@ parts:
   spark8t:
     plugin: python
     python-packages:
-        - git+https://github.com/canonical/spark-k8s-toolkit-py.git@dpe-3552
+        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.10/spark8t-0.0.10-py3-none-any.whl
     source: .
     build-packages:
         - python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,7 @@ apps:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ apps:
         - home
         - dot-kube-config
   spark-submit:
-    command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py $SPARK8T_EXTRA_CONF
+    command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,9 +39,7 @@ apps:
     command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
-      # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
-      # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
-      # _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
@@ -51,6 +51,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - network-bind
@@ -61,6 +62,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - network-bind
@@ -71,6 +73,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ apps:
     command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
-      SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
+      # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
@@ -104,7 +104,7 @@ parts:
   spark8t:
     plugin: python
     python-packages:
-        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.7/spark8t-0.0.7-py3-none-any.whl
+        - git+https://github.com/canonical/spark-k8s-toolkit-py.git@dpe-3552
     source: .
     build-packages:
         - python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
-      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      # _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
-      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.debug=all -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ apps:
     command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py $SPARK8T_EXTRA_CONF
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
-      # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
+      SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
       # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,9 +39,9 @@ apps:
     command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py $SPARK8T_EXTRA_CONF
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
-      SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
+      # SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA"
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
-      JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+      # JDK_JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
         - network
         - home

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -361,7 +361,7 @@ run_spark_submit_custom_certificate(){
   set -x 
   spark-client.service-account-registry delete --username hello
   source microceph.source
-
+  NAMESPACE="default"
   echo "MICRO-CEPH credentials"
   echo $S3_SERVER_URL
   echo $S3_ACCESS_KEY

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -3,7 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 
 # Import reusable utilities
-# source ./tests/integration/utils/s3-utils.sh
+source ./tests/integration/utils/s3-utils.sh
 source ./tests/integration/utils/azure-utils.sh
 
 
@@ -437,7 +437,7 @@ run_spark_submit_custom_certificate(){
   
  #  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
 
-  spark-client.spark-submit --username hello --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4.2-22.04_edge --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
 
   # kubectl --kubeconfig=${KUBE_CONFIG} get pods
   DRIVER_JOB=$(kubectl --kubeconfig=${KUBE_CONFIG} get pods -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -583,23 +583,23 @@ echo -e "##################################"
 
 setup_tests
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN SPARK SHELL JOB"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN SPARK SHELL JOB"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN SPARK SQL JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN SPARK SQL JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
 
 echo -e "##################################"
 echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
@@ -607,48 +607,48 @@ echo -e "##################################"
 
 (setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
+# echo -e "##################################"
 
-(setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
+# (setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "TEST KUBECONFIG ENV VARIABLE"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "TEST KUBECONFIG ENV VARIABLE"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
 
 
-echo -e "##################################"
-echo -e "TEST SELF SIGNED CERTIFICATE"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "TEST SELF SIGNED CERTIFICATE"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_submit_custom_certificate && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_submit_custom_certificate && cleanup_user_success) || cleanup_user_failure
 
 echo -e "##################################"
 echo -e "END OF THE TEST!"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -405,6 +405,7 @@ run_spark_submit_custom_certificate(){
   cp $S3_CA_BUNDLE_PATH ca.pem
   
   cp /etc/ssl/certs/java/cacerts cacerts
+  cp /etc/ssl/certs/adoptium/cacerts cacerts
   ls -larth
   # create certificate for running the Spark Job
   # keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -3,7 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 
 # Import reusable utilities
-source ./tests/integration/utils/s3-utils.sh
+# source ./tests/integration/utils/s3-utils.sh
 source ./tests/integration/utils/azure-utils.sh
 
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -583,23 +583,23 @@ echo -e "##################################"
 
 setup_tests
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN SPARK SHELL JOB"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN SPARK SHELL JOB"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN SPARK SQL JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN SPARK SQL JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
 
 echo -e "##################################"
 echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
@@ -607,48 +607,48 @@ echo -e "##################################"
 
 (setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN PYSPARK JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN PYSPARK JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
+echo -e "##################################"
 
-# (setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
+(setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "TEST KUBECONFIG ENV VARIABLE"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "TEST KUBECONFIG ENV VARIABLE"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
 
 
-# echo -e "##################################"
-# echo -e "TEST SELF SIGNED CERTIFICATE"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "TEST SELF SIGNED CERTIFICATE"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_submit_custom_certificate && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_submit_custom_certificate && cleanup_user_success) || cleanup_user_failure
 
 echo -e "##################################"
 echo -e "END OF THE TEST!"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -419,7 +419,7 @@ run_spark_submit_custom_certificate(){
   echo "Configure Service account with the new certificate"
   spark-client.service-account-registry add-config --username hello \
       --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
-      --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
+      --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.debug=SSL,handshake,data,trustmanager" \
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4-22.04_edge

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -183,6 +183,7 @@ run_spark_shell() {
   echo -e "$(cat ./tests/integration/resources/test-spark-shell.scala | spark-client.spark-shell \
       --username=${USERNAME} \
       --conf spark.kubernetes.container.image=$SPARK_IMAGE \
+      --conf spark.executor.instances=2) \
       --namespace ${NAMESPACE})" \
       > spark-shell.out
   pi=$(cat spark-shell.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-3)

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -370,7 +370,7 @@ run_spark_submit_custom_certificate(){
 
   aws configure set aws_access_key_id $S3_ACCESS_KEY
   aws configure set aws_secret_access_key $S3_SECRET_KEY
-  aws configure set default.region "us-east-2"
+  aws configure set default.region "us-east-1"
 
   aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 mb "s3://dist-cache" 
   aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 mb "s3://history-server"
@@ -395,16 +395,16 @@ run_spark_submit_custom_certificate(){
   sudo apt install s3cmd -y
   echo "Generate truststore"
 
-  cp $S3_CA_BUNDLE_PATH spark.trustore
+  cp $S3_CA_BUNDLE_PATH spark.truststore
 
 
-  keytool -import -alias ceph-cert -file spark.trustore -storetype JKS -keystore cacerts -storepass changeit -noprompt
+  keytool -import -alias ceph-cert -file spark.truststore -storetype JKS -keystore cacerts -storepass changeit -noprompt
   
   echo "Create secret for truststore"
   sudo microk8s.kubectl create secret generic spark-truststore --from-file spark.truststore
   # Import certificate
   echo "Import certificate"
-  spark-client.import-certificate ceph-cert spark.trustore
+  spark-client.import-certificate ceph-cert spark.truststore
   echo "Configure Service account"
   spark-client.service-account-registry add-config --username hello \
       --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -415,7 +415,7 @@ run_spark_submit_custom_certificate(){
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello
   echo "Run Spark job"
-  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --conf spark.kubernetes.container.image=ghcr.io/welpaolo/charmed-spark@sha256:d8273bd904bb5f74234bc0756d520115b5668e2ac4f2b65a677bfb1c27e882da --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
   
   
   # kubectl --kubeconfig=${KUBE_CONFIG} get pods

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -396,10 +396,11 @@ run_spark_submit_custom_certificate(){
   echo "Generate truststore"
 
   cp $S3_CA_BUNDLE_PATH ca.pem
-
+  cat ca.pem
   keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt
-
+  ls -larth
   mv cacerts spark.truststore
+  cat spark.truststore
   echo "Create secret for truststore"
   sudo microk8s.kubectl create secret generic spark-truststore --from-file spark.truststore
   # Import certificate
@@ -441,6 +442,7 @@ run_spark_submit_custom_certificate(){
   pi=$(kubectl --kubeconfig=${KUBE_CONFIG} logs $(kubectl --kubeconfig=${KUBE_CONFIG} get pods -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)  -n ${NAMESPACE} | grep 'Pi is roughly' | rev | cut -d' ' -f1 | rev | cut -c 1-3)
   echo -e "Spark Pi Job Output: \n ${pi}"
 
+  aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 ls "s3://dist-cache" 
   validate_pi_value $pi
 
   

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -415,7 +415,7 @@ run_spark_submit_custom_certificate(){
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello
   echo "Run Spark job"
-  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
   
   
   # kubectl --kubeconfig=${KUBE_CONFIG} get pods

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -433,8 +433,10 @@ run_spark_submit_custom_certificate(){
   spark-client.service-account-registry get-config --username hello
 
   echo "Run Spark job"
-  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  # spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
   
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+
   
   # kubectl --kubeconfig=${KUBE_CONFIG} get pods
   DRIVER_JOB=$(kubectl --kubeconfig=${KUBE_CONFIG} get pods -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -372,8 +372,8 @@ run_spark_submit_custom_certificate(){
   aws configure set aws_secret_access_key $S3_SECRET_KEY
   aws configure set default.region "us-east-2"
 
-  aws --endpoint-url "$S3_SERVER_URL" s3 mb "s3://dist-cache"
-  aws --endpoint-url "$S3_SERVER_URL" s3 mb "s3://history-server"
+  aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 mb "s3://dist-cache" 
+  aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 mb "s3://history-server"
 
   # aws --endpoint-url "http://$S3_SERVER_URL" s3 cp FILE s3://""/"$BASE_NAME"
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -404,6 +404,7 @@ run_spark_submit_custom_certificate(){
   echo "Generate truststore"
   cp $S3_CA_BUNDLE_PATH ca.pem
   
+  cp /etc/ssl/certs/java/cacerts cacerts
   # create certificate for running the Spark Job
   keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -427,7 +427,7 @@ run_spark_submit_custom_certificate(){
       --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore \
-      --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4-22.04_edge
+      --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark@sha256:f5cbbceb09818a51129f05473fee5d01c4a18d19e0a900179c2c099476af3c16
   
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -4,7 +4,7 @@
 
 # Import reusable utilities
 source ./tests/integration/utils/s3-utils.sh
-source ./tests/integration/utils/azure-utils.sh
+# source ./tests/integration/utils/azure-utils.sh
 
 
 readonly SPARK_IMAGE='ghcr.io/canonical/charmed-spark:3.4-22.04_edge'
@@ -359,6 +359,7 @@ test_spark_submit_custom_certificate() {
 
 run_spark_submit_custom_certificate(){
   set -x 
+  KUBE_CONFIG=/home/${USER}/.kube/config
   spark-client.service-account-registry delete --username hello
   source microceph.source
   NAMESPACE="default"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -220,7 +220,6 @@ run_pyspark(){
   return $?
 }
 
-
 test_pyspark_with_s3(){
   temp_script_file=/tmp/test-pyspark-s3.py
   example_txt_path=s3a://${S3_BUCKET}/example.txt
@@ -354,6 +353,10 @@ test_example_job_with_s3() {
   fi
 }
 
+test_spark_submit_custom_certificate() {
+  run_spark_submit_custom_certificate
+}
+
 run_spark_submit_custom_certificate(){
 
   spark-client.service-account-registry delete --username hello
@@ -369,6 +372,9 @@ run_spark_submit_custom_certificate(){
   aws configure set aws_secret_access_key $S3_SECRET_KEY
   aws configure set default.region "us-east-2"
 
+  aws --endpoint-url "http://$S3_SERVER_URL" s3 mb "s3://dist-cache"
+  aws --endpoint-url "http://$S3_SERVER_URL" s3 mb "s3://history-server"
+
   # aws --endpoint-url "http://$S3_SERVER_URL" s3 cp FILE s3://""/"$BASE_NAME"
 
   spark-client.service-account-registry create --username hello \
@@ -379,6 +385,7 @@ run_spark_submit_custom_certificate(){
     --conf spark.hadoop.fs.s3a.connection.ssl.enabled=false \
     --conf spark.hadoop.fs.s3a.path.style.access=true \
     --conf spark.eventLog.enabled=true \
+    --conf spark.kubernetes.file.upload.path=s3a://dist-cache/ \
     --conf spark.eventLog.dir=s3a://history-server/spark-events/ \
     --conf spark.history.fs.logDirectory=s3a://history-server/spark-events/
 
@@ -592,3 +599,4 @@ echo -e "##################################"
 echo -e "##################################"
 echo -e "END OF THE TEST!"
 echo -e "##################################"
+

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -587,61 +587,61 @@ echo -e "##################################"
 echo -e "RUN EXAMPLE JOB"
 echo -e "##################################"
 
-(setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN SPARK SHELL JOB"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN SPARK SHELL JOB"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN SPARK SQL JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN SPARK SQL JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH S3"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH S3"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
+# echo -e "##################################"
 
-(setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
+# (setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
 
-echo -e "##################################"
-echo -e "TEST KUBECONFIG ENV VARIABLE"
-echo -e "##################################"
+# echo -e "##################################"
+# echo -e "TEST KUBECONFIG ENV VARIABLE"
+# echo -e "##################################"
 
-(setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+# (setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
 
 
 echo -e "##################################"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -455,8 +455,7 @@ run_spark_submit_custom_certificate(){
 
   aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 ls "s3://dist-cache" 
   validate_pi_value $pi
-  
-  set +x
+
 }
 
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -421,7 +421,8 @@ run_spark_submit_custom_certificate(){
       --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
       --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
-      --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore 
+      --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore \
+      --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark-gpu:3.4-22.04_edge
   
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -358,7 +358,7 @@ test_spark_submit_custom_certificate() {
 }
 
 run_spark_submit_custom_certificate(){
-
+  set -x 
   spark-client.service-account-registry delete --username hello
   source microceph.source
 
@@ -412,7 +412,8 @@ run_spark_submit_custom_certificate(){
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore 
   echo "Run Spark job"
-  spark-client.spark-submit --username hello --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.1.jar 100
+  spark-client.spark-submit --username hello --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  set +x
 }
 
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -394,13 +394,17 @@ run_spark_submit_custom_certificate(){
   
   sudo apt install s3cmd -y
   echo "Generate truststore"
-  keytool -import -alias ceph-cert -file $S3_CA_BUNDLE_PATH -storetype JKS -keystore cacerts -storepass changeit -noprompt
-  mv cacerts spark.truststore
+
+  cp $S3_CA_BUNDLE_PATH spark.trustore
+
+
+  keytool -import -alias ceph-cert -file spark.trustore -storetype JKS -keystore cacerts -storepass changeit -noprompt
+  
   echo "Create secret for truststore"
   sudo microk8s.kubectl create secret generic spark-truststore --from-file spark.truststore
   # Import certificate
   echo "Import certificate"
-  spark-client.import-certificate ceph-cert $S3_CA_BUNDLE_PATH
+  spark-client.import-certificate ceph-cert spark.trustore
   echo "Configure Service account"
   spark-client.service-account-registry add-config --username hello \
       --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -372,8 +372,8 @@ run_spark_submit_custom_certificate(){
   aws configure set aws_secret_access_key $S3_SECRET_KEY
   aws configure set default.region "us-east-2"
 
-  aws --endpoint-url "http://$S3_SERVER_URL" s3 mb "s3://dist-cache"
-  aws --endpoint-url "http://$S3_SERVER_URL" s3 mb "s3://history-server"
+  aws --endpoint-url "$S3_SERVER_URL" s3 mb "s3://dist-cache"
+  aws --endpoint-url "$S3_SERVER_URL" s3 mb "s3://history-server"
 
   # aws --endpoint-url "http://$S3_SERVER_URL" s3 cp FILE s3://""/"$BASE_NAME"
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -575,65 +575,72 @@ echo -e "##################################"
 
 setup_tests
 
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN SPARK SHELL JOB"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN SPARK SQL JOB WITH S3"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH S3"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH S3"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
+# echo -e "##################################"
+
+# (setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
+
+# echo -e "##################################"
+# echo -e "TEST KUBECONFIG ENV VARIABLE"
+# echo -e "##################################"
+
+# (setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+
+
 echo -e "##################################"
-echo -e "RUN EXAMPLE JOB"
+echo -e "TEST SELF SIGNED CERTIFICATE"
 echo -e "##################################"
 
-(setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN SPARK SHELL JOB"
-echo -e "##################################"
-
-(setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN SPARK SQL JOB WITH S3"
-echo -e "##################################"
-
-(setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
-echo -e "##################################"
-
-(setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH S#"
-echo -e "##################################"
-
-(setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
-echo -e "##################################"
-
-(setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH S3"
-echo -e "##################################"
-
-(setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
-echo -e "##################################"
-
-(setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
-echo -e "##################################"
-
-(setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
-
-echo -e "##################################"
-echo -e "TEST KUBECONFIG ENV VARIABLE"
-echo -e "##################################"
-
-(setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_submit_custom_certificate && cleanup_user_success) || cleanup_user_failure
 
 echo -e "##################################"
 echo -e "END OF THE TEST!"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -391,6 +391,8 @@ run_spark_submit_custom_certificate(){
     --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true \
     --conf spark.hadoop.fs.s3a.path.style.access=true \
     --conf spark.eventLog.enabled=true \
+    --conf spark.hadoop.fs.s3a.fast.upload=true \
+    --conf spark.kubernetes.file.upload.path=s3a://dist-cache/ \
     --conf spark.eventLog.dir=s3a://history-server/ \
     --conf spark.history.fs.logDirectory=s3a://history-server/
 
@@ -435,9 +437,8 @@ run_spark_submit_custom_certificate(){
   
  #  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
 
-  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4.2-22.04_edge --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4.2-22.04_edge --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
 
-  # kubectl --kubeconfig=${KUBE_CONFIG} get pods
   DRIVER_JOB=$(kubectl --kubeconfig=${KUBE_CONFIG} get pods -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)
 
   if [[ "${DRIVER_JOB}" == "${PREVIOUS_JOB}" ]]

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -183,7 +183,7 @@ run_spark_shell() {
   echo -e "$(cat ./tests/integration/resources/test-spark-shell.scala | spark-client.spark-shell \
       --username=${USERNAME} \
       --conf spark.kubernetes.container.image=$SPARK_IMAGE \
-      --conf spark.executor.instances=2) \
+      --conf spark.executor.instances=2 \
       --namespace ${NAMESPACE})" \
       > spark-shell.out
   pi=$(cat spark-shell.out  | grep "^Pi is roughly" | rev | cut -d' ' -f1 | rev | cut -c 1-3)

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -422,7 +422,7 @@ run_spark_submit_custom_certificate(){
       --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore \
-      --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark-gpu:3.4-22.04_edge
+      --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4-22.04_edge
   
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -423,7 +423,7 @@ run_spark_submit_custom_certificate(){
 
   echo "Configure Service account with the new certificate"
   spark-client.service-account-registry add-config --username hello \
-      --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \
+      --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.debug=SSL,handshake,data,trustmanager" \
       --conf spark.driver.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.debug=SSL,handshake,data,trustmanager" \
       --conf spark.kubernetes.executor.secrets.spark-truststore=/spark-truststore \
       --conf spark.kubernetes.driver.secrets.spark-truststore=/spark-truststore \

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -3,7 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 
 # Import reusable utilities
-source ./tests/integration/utils/s3-utils.sh
+# source ./tests/integration/utils/s3-utils.sh
 source ./tests/integration/utils/azure-utils.sh
 
 
@@ -395,6 +395,7 @@ run_spark_submit_custom_certificate(){
     --conf spark.eventLog.dir=s3a://history-server/spark-events/ \
     --conf spark.history.fs.logDirectory=s3a://history-server/spark-events/
 
+  aws --no-verify-ssl --endpoint-url "$S3_SERVER_URL" s3 ls
 
   echo "Actual configs"
   spark-client.service-account-registry get-config --username hello

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -400,15 +400,10 @@ run_spark_submit_custom_certificate(){
 
   echo "Actual configs"
   spark-client.service-account-registry get-config --username hello
-  
 
   echo "Generate truststore"
   cp $S3_CA_BUNDLE_PATH ca.pem
-  
-  # cp /etc/ssl/certs/java/cacerts cacerts
-  # cp /etc/ssl/certs/adoptium/cacerts cacerts
-  # chmod 777 cacerts
-  # ls -larth
+
   # create certificate for running the Spark Job
   keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt
   ls -larth
@@ -433,10 +428,6 @@ run_spark_submit_custom_certificate(){
   spark-client.service-account-registry get-config --username hello
 
   echo "Run Spark job"
-  # spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
-  
- #  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
-
   spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.container.image=ghcr.io/canonical/charmed-spark:3.4.2-22.04_edge --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/example.txt" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
 
   DRIVER_JOB=$(kubectl --kubeconfig=${KUBE_CONFIG} get pods -n ${NAMESPACE} | grep driver | tail -n 1 | cut -d' ' -f1)
@@ -596,61 +587,61 @@ echo -e "##################################"
 echo -e "RUN EXAMPLE JOB"
 echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_pi_example && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN SPARK SHELL JOB"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN SPARK SHELL JOB"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_shell && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN SPARK SQL JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN SPARK SQL JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_sql_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN SPARK SQL JOB WITH AZURE ABFSS"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_spark_sql_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN PYSPARK JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN PYSPARK JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_pyspark_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN PYSPARK JOB WITH AZURE ABFSS"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_pyspark_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB WITH S3"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB WITH S3"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_example_job_with_s3 && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE JOB WITH AZURE ABFSS"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_example_job_with_azure_abfss && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "RUN EXAMPLE WITH RESTRICTED ACCOUNT"
+echo -e "##################################"
 
-# (setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
+(setup_user_restricted_context && test_restricted_account && cleanup_user_success) || cleanup_user_failure
 
-# echo -e "##################################"
-# echo -e "TEST KUBECONFIG ENV VARIABLE"
-# echo -e "##################################"
+echo -e "##################################"
+echo -e "TEST KUBECONFIG ENV VARIABLE"
+echo -e "##################################"
 
-# (setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
+(setup_user_admin_context && test_custom_kubeconfig_example && cleanup_user_success) || cleanup_user_failure
 
 
 echo -e "##################################"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -405,9 +405,11 @@ run_spark_submit_custom_certificate(){
   cp $S3_CA_BUNDLE_PATH ca.pem
   
   cp /etc/ssl/certs/java/cacerts cacerts
+  ls -larth
   # create certificate for running the Spark Job
-  keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt
-
+  # keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt
+  keytool -import -v -alias ceph-cert -file ca.pem -storepass changeit -noprompt -keystore cacerts
+  ls -larth
   mv cacerts spark.truststore
 
   echo "Create secret for truststore"

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -414,7 +414,7 @@ run_spark_submit_custom_certificate(){
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello
   echo "Run Spark job"
-  spark-client.spark-submit --username hello --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
   set +x
 }
 

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -415,7 +415,7 @@ run_spark_submit_custom_certificate(){
   echo "Print current config."
   spark-client.service-account-registry get-config --username hello
   echo "Run Spark job"
-  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --conf spark.kubernetes.container.image=ghcr.io/welpaolo/charmed-spark@sha256:d8273bd904bb5f74234bc0756d520115b5668e2ac4f2b65a677bfb1c27e882da --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
+  spark-client.spark-submit --username hello -v --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true --conf spark.kubernetes.executor.request.cores=0.1 --files="./tests/integration/resources/testpod.yaml" --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 100
   
   
   # kubectl --kubeconfig=${KUBE_CONFIG} get pods

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -382,7 +382,7 @@ run_spark_submit_custom_certificate(){
     --conf spark.hadoop.fs.s3a.secret.key=$S3_SECRET_KEY \
     --conf spark.hadoop.fs.s3a.endpoint=$S3_SERVER_URL \
     --conf spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider \
-    --conf spark.hadoop.fs.s3a.connection.ssl.enabled=false \
+    --conf spark.hadoop.fs.s3a.connection.ssl.enabled=true \
     --conf spark.hadoop.fs.s3a.path.style.access=true \
     --conf spark.eventLog.enabled=true \
     --conf spark.kubernetes.file.upload.path=s3a://dist-cache/ \
@@ -404,7 +404,7 @@ run_spark_submit_custom_certificate(){
   sudo microk8s.kubectl create secret generic spark-truststore --from-file spark.truststore
   # Import certificate
   echo "Import certificate"
-  spark-client.import-certificate ceph-cert spark.truststore
+  spark-client.import-certificate ceph-cert ca.pem
   echo "Configure Service account"
   spark-client.service-account-registry add-config --username hello \
       --conf spark.executor.extraJavaOptions="-Djavax.net.ssl.trustStore=/spark-truststore/spark.truststore -Djavax.net.ssl.trustStorePassword=changeit" \

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -406,6 +406,7 @@ run_spark_submit_custom_certificate(){
   
   cp /etc/ssl/certs/java/cacerts cacerts
   cp /etc/ssl/certs/adoptium/cacerts cacerts
+  chmod 777 cacerts
   ls -larth
   # create certificate for running the Spark Job
   # keytool -import -alias ceph-cert -file ca.pem -storetype JKS -keystore cacerts -storepass changeit -noprompt

--- a/tests/integration/ie-tests.sh
+++ b/tests/integration/ie-tests.sh
@@ -3,7 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 
 # Import reusable utilities
-# source ./tests/integration/utils/s3-utils.sh
+source ./tests/integration/utils/s3-utils.sh
 source ./tests/integration/utils/azure-utils.sh
 
 

--- a/tests/integration/setup-microk8s.sh
+++ b/tests/integration/setup-microk8s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo snap install microk8s --classic
+sudo snap install microk8s --channel=1.28/stable --classic
 sudo snap alias microk8s.kubectl kubectl
 sudo usermod -a -G microk8s ${USER}
 mkdir -p ~/.kube


### PR DESCRIPTION
This PR add support for custom certificate for submitting spark jobs.
This PR includes the addition of the following features and tests:
- Add import certificate feature to store self-signed certificate in the truststore of the snap
- Update version of the spark8t to fix a parsing issue of `javaExtraOptions`
- Add test to validate the correct upload of resource and read/write from microceph deployment behind https 
- 
This version of the spark-client snap uses a feature branch of the `spark8t` library that need to release before merging