### PR TITLE
[DPE-3731] Update spark8t version to support Spark Configuration Hub

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,7 +84,7 @@ parts:
   spark8t:
     plugin: python
     python-packages:
-        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.5/spark8t-0.0.5-py3-none-any.whl
+        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.6/spark8t-0.0.6-py3-none-any.whl
     source: .
     build-packages:
         - python3


### PR DESCRIPTION
This PR update the spark8t library to support the spark-configuration-hub secrets