### PR TITLE
[DPE-7131] Add beeline client to snap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v4
       - id: build-snap
         name: Build snap
-        uses: snapcore/action-build@2ee46bc29d163c9c836f2820cc46b39664bf0de2
+        uses: snapcore/action-build@v1
         with:
-          snapcraft-channel: 7.x/candidate
+          snapcraft-channel: 8.x/stable
       - id: upload
         name: Upload built snap job artifact
         uses: actions/upload-artifact@v4

--- a/snap/local/opt/spark/bin/beeline
+++ b/snap/local/opt/spark/bin/beeline
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Shell script for starting BeeLine
+
+# Enter posix mode for bash
+set -o posix
+
+# Figure out if SPARK_HOME is set
+if [ -z "${SPARK_HOME}" ]; then
+  source "$(dirname "$0")"/find-spark-home
+fi
+
+# Overwrite URL to include default truststore if none is passed
+JDBC_REGEX="^jdbc:hive2://[^/]"
+args=()
+while (( $# )); do
+  args=("${args[@]}" "$1")
+  if [ $1 == "-u" ]; then
+    if [ -n $2 ] && [ $2=~$JDBC ]; then
+      URI=$(echo "${2%;}" | sed '/sslTrustStore/!s/$/;sslTrustStore=\/var\/snap\/spark-client\/current\/etc\/ssl\/certs\/java\/cacerts/')
+      args=("${args[@]}" "${URI}")
+      shift
+    fi
+  fi
+  shift
+done
+
+CLASS="org.apache.hive.beeline.BeeLine"
+exec "${SPARK_HOME}/bin/spark-class" $CLASS "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,12 +134,21 @@ parts:
       # Create the target directory and extract the tarball for Kyuubi
       KYUUBI_DIR=$CRAFT_PART_INSTALL/opt/kyuubi
       mkdir -p $KYUUBI_DIR/bin
+      mkdir -p $KYUUBI_DIR/logs
+      mkdir -p $KYUUBI_DIR/work
+      mkdir -p $KYUUBI_DIR/pid
+      mkdir -p $KYUUBI_DIR/externals/kyuubi-download/target
       mkdir kyuubi
       tar -xzvf $KYUUBI_TARFILE -C kyuubi/ --strip-components=1
 
+      # Resolve beeline jars symlinks, save ~50MB compared to copying kyuubi jars folder
+      for f in $(find kyuubi/beeline-jars -maxdepth 1 -type l)
+      do
+          cp --remove-destination $(readlink -e $f) $f
+      done
+
       # Stage beeline files
       cp -r kyuubi/beeline-jars $KYUUBI_DIR
-      cp -r kyuubi/jars $KYUUBI_DIR
       cp kyuubi/bin/kyuubi-beeline $KYUUBI_DIR/bin
       cp kyuubi/bin/load-kyuubi-env.sh $KYUUBI_DIR/bin
       chmod -R +x $KYUUBI_DIR/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: spark-client
 base: core22
-version: "3.5.1"
+version: "3.5.4"
 summary: Client side scripts to submit Spark jobs to a cluster.
 description: |
   The spark-client snap includes the scripts spark-submit, spark-shell, pyspark and other tools for managing Apache Spark jobs.
@@ -89,7 +89,7 @@ apps:
       - dot-kube-config
 
   beeline:
-    command: /opt/kyuubi/bin/kyuubi-beeline
+    command: /opt/spark/bin/beeline
     environment:
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:
@@ -165,41 +165,6 @@ parts:
       rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs
       # move base certs data
       mv etc/ssl/certs/java/cacerts etc/cacerts
-
-  kyuubi-beeline:
-    plugin: nil
-    build-packages:
-      - wget
-    override-build: |
-      KYUUBI_ARTIFACT="https://dlcdn.apache.org/kyuubi/kyuubi-1.10.1/apache-kyuubi-1.10.1-bin.tgz"
-      KYUUBI_512_CHECKSUM="9b565bb7c628a50ecd394741eedb9a5154590709603e26f81de88ffd3b5256603215e71160de61360b8f2e2842116026c2f9ed3a60a8f0356388e3dd2c00b84c"
-      KYUUBI_TARFILE="kyuubi.tar.tgz"
-
-      # Download and verify Kyuubi
-      wget -O $KYUUBI_TARFILE $KYUUBI_ARTIFACT
-      echo "$KYUUBI_512_CHECKSUM  $KYUUBI_TARFILE" | sha512sum -c -
-
-      # Create the target directories and extract the tarball for Kyuubi
-      KYUUBI_DIR=$CRAFT_PART_INSTALL/opt/kyuubi
-      mkdir -p $KYUUBI_DIR/bin
-      mkdir -p $KYUUBI_DIR/logs
-      mkdir -p $KYUUBI_DIR/work
-      mkdir -p $KYUUBI_DIR/pid
-      mkdir -p $KYUUBI_DIR/externals/kyuubi-download/target
-      mkdir kyuubi
-      tar -xzvf $KYUUBI_TARFILE -C kyuubi/ --strip-components=1
-
-      # Resolve beeline jars symlinks, save ~50MB compared to copying kyuubi jars folder
-      for f in $(find kyuubi/beeline-jars -maxdepth 1 -type l)
-      do
-          cp --remove-destination $(readlink -e $f) $f
-      done
-
-      # Stage beeline files
-      cp -r kyuubi/beeline-jars $KYUUBI_DIR
-      cp kyuubi/bin/kyuubi-beeline $KYUUBI_DIR/bin
-      cp kyuubi/bin/load-kyuubi-env.sh $KYUUBI_DIR/bin
-      chmod -R +x $KYUUBI_DIR/bin
 
   kubectl:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,6 +154,7 @@ parts:
       cd "spark-${SPARK_VERSION}-bin-k8s/"
       SPARK_DIR=$CRAFT_PART_INSTALL/opt/spark
       mkdir -p $SPARK_DIR/bin
+      rm bin/beeline
       cp -r bin/* $SPARK_DIR/bin
       mkdir -p $SPARK_DIR/jars
       cp -r jars/* $SPARK_DIR/jars

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,7 +134,7 @@ parts:
       TARBALL_URL="https://github.com/canonical/central-uploader/releases/download/spark-${TAG}/spark-${SPARK_VERSION}-bin-k8s.tgz"
       CHECKSUM_URL="${TARBALL_URL}.sha512"
 
-      STATUSCODE=$(curl --silent --head $TARBALL_URL | head -n 1 | cut -d' ' -f2)
+      STATUSCODE=$(curl -o /dev/null -s -w "%{http_code}\n" $TARBALL_URL)
 
       if  [[ ${STATUSCODE} -gt 400 ]]
         then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,8 @@ apps:
 
   beeline:
     command: /opt/kyuubi/bin/kyuubi-beeline
+    environment:
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:
       - network
       - network-bind
@@ -116,43 +118,6 @@ parts:
       craftctl default
       # Scripts must be executable
       chmod -R 755 $CRAFT_PART_INSTALL/lib/python3.10/site-packages/spark8t/cli/
-
-  kyuubi-beeline:
-    plugin: nil
-    build-packages:
-      - openjdk-17-jre-headless
-      - wget
-    override-build: |
-      KYUUBI_ARTIFACT="https://dlcdn.apache.org/kyuubi/kyuubi-1.10.1/apache-kyuubi-1.10.1-bin.tgz"
-      KYUUBI_512_CHECKSUM="9b565bb7c628a50ecd394741eedb9a5154590709603e26f81de88ffd3b5256603215e71160de61360b8f2e2842116026c2f9ed3a60a8f0356388e3dd2c00b84c"
-      KYUUBI_TARFILE="kyuubi.tar.tgz"
-
-      # Download and verify Kyuubi
-      wget -O $KYUUBI_TARFILE $KYUUBI_ARTIFACT
-      echo "$KYUUBI_512_CHECKSUM  $KYUUBI_TARFILE" | sha512sum -c -
-
-      # Create the target directory and extract the tarball for Kyuubi
-      KYUUBI_DIR=$CRAFT_PART_INSTALL/opt/kyuubi
-      mkdir -p $KYUUBI_DIR/bin
-      mkdir -p $KYUUBI_DIR/logs
-      mkdir -p $KYUUBI_DIR/work
-      mkdir -p $KYUUBI_DIR/pid
-      mkdir -p $KYUUBI_DIR/externals/kyuubi-download/target
-      mkdir kyuubi
-      tar -xzvf $KYUUBI_TARFILE -C kyuubi/ --strip-components=1
-
-      # Resolve beeline jars symlinks, save ~50MB compared to copying kyuubi jars folder
-      for f in $(find kyuubi/beeline-jars -maxdepth 1 -type l)
-      do
-          cp --remove-destination $(readlink -e $f) $f
-      done
-
-      # Stage beeline files
-      cp -r kyuubi/beeline-jars $KYUUBI_DIR
-      cp kyuubi/bin/kyuubi-beeline $KYUUBI_DIR/bin
-      cp kyuubi/bin/load-kyuubi-env.sh $KYUUBI_DIR/bin
-      chmod -R +x $KYUUBI_DIR/bin
-      
 
   spark:
     plugin: nil
@@ -200,6 +165,41 @@ parts:
       rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs
       # move base certs data
       mv etc/ssl/certs/java/cacerts etc/cacerts
+
+  kyuubi-beeline:
+    plugin: nil
+    build-packages:
+      - wget
+    override-build: |
+      KYUUBI_ARTIFACT="https://dlcdn.apache.org/kyuubi/kyuubi-1.10.1/apache-kyuubi-1.10.1-bin.tgz"
+      KYUUBI_512_CHECKSUM="9b565bb7c628a50ecd394741eedb9a5154590709603e26f81de88ffd3b5256603215e71160de61360b8f2e2842116026c2f9ed3a60a8f0356388e3dd2c00b84c"
+      KYUUBI_TARFILE="kyuubi.tar.tgz"
+
+      # Download and verify Kyuubi
+      wget -O $KYUUBI_TARFILE $KYUUBI_ARTIFACT
+      echo "$KYUUBI_512_CHECKSUM  $KYUUBI_TARFILE" | sha512sum -c -
+
+      # Create the target directories and extract the tarball for Kyuubi
+      KYUUBI_DIR=$CRAFT_PART_INSTALL/opt/kyuubi
+      mkdir -p $KYUUBI_DIR/bin
+      mkdir -p $KYUUBI_DIR/logs
+      mkdir -p $KYUUBI_DIR/work
+      mkdir -p $KYUUBI_DIR/pid
+      mkdir -p $KYUUBI_DIR/externals/kyuubi-download/target
+      mkdir kyuubi
+      tar -xzvf $KYUUBI_TARFILE -C kyuubi/ --strip-components=1
+
+      # Resolve beeline jars symlinks, save ~50MB compared to copying kyuubi jars folder
+      for f in $(find kyuubi/beeline-jars -maxdepth 1 -type l)
+      do
+          cp --remove-destination $(readlink -e $f) $f
+      done
+
+      # Stage beeline files
+      cp -r kyuubi/beeline-jars $KYUUBI_DIR
+      cp kyuubi/bin/kyuubi-beeline $KYUUBI_DIR/bin
+      cp kyuubi/bin/load-kyuubi-env.sh $KYUUBI_DIR/bin
+      chmod -R +x $KYUUBI_DIR/bin
 
   kubectl:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: spark-client
 base: core22
-version: '3.5.1'
+version: "3.5.1"
 summary: Client side scripts to submit Spark jobs to a cluster.
 description: |
   The spark-client snap includes the scripts spark-submit, spark-shell, pyspark and other tools for managing Apache Spark jobs.
@@ -10,14 +10,14 @@ confinement: strict
 
 hooks:
   install:
-    plugs: 
+    plugs:
       - home
 
 plugs:
   dot-kube-config:
     interface: personal-files
     read:
-    - $HOME/.kube/config
+      - $HOME/.kube/config
 
 environment:
   JAVA_HOME: $SNAP/usr/lib/jvm/java-17-openjdk-amd64
@@ -32,18 +32,18 @@ apps:
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$SNAP/local/lib/dist-packages/:$SNAP/local/lib/dist-packages/spark8t/cli:$PYTHONPATH
     plugs:
-        - network
-        - home
-        - dot-kube-config
+      - network
+      - home
+      - dot-kube-config
   spark-submit:
-    command:  etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
+    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
     environment:
       PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
-        - network
-        - home
-        - dot-kube-config
+      - network
+      - home
+      - dot-kube-config
   spark-shell:
     command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_shell.py $SPARK8T_EXTRA_CONF
     environment:
@@ -51,10 +51,10 @@ apps:
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
-        - network
-        - network-bind
-        - home
-        - dot-kube-config
+      - network
+      - network-bind
+      - home
+      - dot-kube-config
   pyspark:
     command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/pyspark.py $SPARK8T_EXTRA_CONF
     environment:
@@ -62,10 +62,10 @@ apps:
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
-        - network
-        - network-bind
-        - home
-        - dot-kube-config
+      - network
+      - network-bind
+      - home
+      - dot-kube-config
   spark-sql:
     command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_sql.py $SPARK8T_EXTRA_CONF
     environment:
@@ -73,23 +73,28 @@ apps:
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
-        - network
-        - network-bind
-        - home
-        - dot-kube-config
+      - network
+      - network-bind
+      - home
+      - dot-kube-config
 
   import-certificate:
     command: etc/spark8t/bin/import-certificate.sh
     environment:
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:
-        - network
-        - network-bind
-        - home
-        - dot-kube-config
+      - network
+      - network-bind
+      - home
+      - dot-kube-config
+
+  beeline:
+    command: /opt/kyuubi/bin/kyuubi-beeline
+    plugs:
+      - network
+      - network-bind
 
 parts:
-
   spark8t-conf:
     plugin: dump
     source: snap/local
@@ -102,66 +107,95 @@ parts:
   spark8t:
     plugin: python
     python-packages:
-        - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.10/spark8t-0.0.10-py3-none-any.whl
+      - https://github.com/canonical/spark-k8s-toolkit-py/releases/download/v0.0.10/spark8t-0.0.10-py3-none-any.whl
     source: .
     build-packages:
-        - python3
-        - pip
+      - python3
+      - pip
     override-build: |
-        craftctl default
-        # Scripts must be executable
-        chmod -R 755 $CRAFT_PART_INSTALL/lib/python3.10/site-packages/spark8t/cli/
+      craftctl default
+      # Scripts must be executable
+      chmod -R 755 $CRAFT_PART_INSTALL/lib/python3.10/site-packages/spark8t/cli/
+
+  kyuubi-beeline:
+    plugin: nil
+    build-packages:
+      - openjdk-17-jre-headless
+      - wget
+    override-build: |
+      KYUUBI_ARTIFACT="https://dlcdn.apache.org/kyuubi/kyuubi-1.10.1/apache-kyuubi-1.10.1-bin.tgz"
+      KYUUBI_512_CHECKSUM="9b565bb7c628a50ecd394741eedb9a5154590709603e26f81de88ffd3b5256603215e71160de61360b8f2e2842116026c2f9ed3a60a8f0356388e3dd2c00b84c"
+      KYUUBI_TARFILE="kyuubi.tar.tgz"
+
+      # Download and verify Kyuubi
+      wget -O $KYUUBI_TARFILE $KYUUBI_ARTIFACT
+      echo "$KYUUBI_512_CHECKSUM  $KYUUBI_TARFILE" | sha512sum -c -
+
+      # Create the target directory and extract the tarball for Kyuubi
+      KYUUBI_DIR=$CRAFT_PART_INSTALL/opt/kyuubi
+      mkdir -p $KYUUBI_DIR/bin
+      mkdir kyuubi
+      tar -xzvf $KYUUBI_TARFILE -C kyuubi/ --strip-components=1
+
+      # Stage beeline files
+      cp -r kyuubi/beeline-jars $KYUUBI_DIR
+      cp -r kyuubi/jars $KYUUBI_DIR
+      cp kyuubi/bin/kyuubi-beeline $KYUUBI_DIR/bin
+      cp kyuubi/bin/load-kyuubi-env.sh $KYUUBI_DIR/bin
+      chmod -R +x $KYUUBI_DIR/bin
+      
 
   spark:
     plugin: nil
     build-packages:
-        - ca-certificates
-        - ca-certificates-java
-        - openjdk-17-jre-headless
-        - wget
+      - ca-certificates
+      - ca-certificates-java
+      - openjdk-17-jre-headless
+      - wget
     stage-packages:
-        - openjdk-17-jre-headless
+      - openjdk-17-jre-headless
     override-build: |
-        SPARK_VERSION=$(cat $CRAFT_PROJECT_DIR/SPARK_VERSION | tr -d '\n')
-        TAG=$( echo ${SPARK_VERSION%-*} )
-        TARBALL_URL="https://github.com/canonical/central-uploader/releases/download/spark-${TAG}/spark-${SPARK_VERSION}-bin-k8s.tgz"
-        CHECKSUM_URL="${TARBALL_URL}.sha512"
+      SPARK_VERSION=$(cat $CRAFT_PROJECT_DIR/SPARK_VERSION | tr -d '\n')
+      TAG=$( echo ${SPARK_VERSION%-*} )
+      TARBALL_URL="https://github.com/canonical/central-uploader/releases/download/spark-${TAG}/spark-${SPARK_VERSION}-bin-k8s.tgz"
+      CHECKSUM_URL="${TARBALL_URL}.sha512"
 
-        STATUSCODE=$(curl --silent --head $TARBALL_URL | head -n 1 | cut -d' ' -f2)
-        
-        if  [[ ${STATUSCODE} -gt 400 ]]
-          then
-            echo "ERROR: Latest available Spark version spark-${SPARK_VERSION} does not have a downloadable binary! Exiting...."
-            exit 1
-        fi
-        echo "Downloading latest available Spark version spark-${SPARK_VERSION}."
-        wget $TARBALL_URL
-        wget $CHECKSUM_URL
-        sha512sum --check "spark-${SPARK_VERSION}-bin-k8s.tgz.sha512"
-        if  [[ $? -ne 0 ]]
-          then
-            echo "DOWNLOAD ERROR: Latest available Spark version spark-${SPARK_VERSION} could not be downloaded properly! Exiting...."
-            exit 1
-        fi
-        tar -zxf "spark-${SPARK_VERSION}-bin-k8s.tgz"
-        cd "spark-${SPARK_VERSION}-bin-k8s/"
-        SPARK_DIR=$CRAFT_PART_INSTALL/opt/spark
-        mkdir -p $SPARK_DIR/bin
-        cp -r bin/* $SPARK_DIR/bin
-        mkdir -p $SPARK_DIR/jars
-        cp -r jars/* $SPARK_DIR/jars
-        mkdir -p $SPARK_DIR/python
-        cp -r python/* $SPARK_DIR/python/
+      STATUSCODE=$(curl --silent --head $TARBALL_URL | head -n 1 | cut -d' ' -f2)
+
+      if  [[ ${STATUSCODE} -gt 400 ]]
+        then
+          echo "ERROR: Latest available Spark version spark-${SPARK_VERSION} does not have a downloadable binary! Exiting...."
+          exit 1
+      fi
+      echo "Downloading latest available Spark version spark-${SPARK_VERSION}."
+      wget $TARBALL_URL
+      wget $CHECKSUM_URL
+      sha512sum --check "spark-${SPARK_VERSION}-bin-k8s.tgz.sha512"
+      if  [[ $? -ne 0 ]]
+        then
+          echo "DOWNLOAD ERROR: Latest available Spark version spark-${SPARK_VERSION} could not be downloaded properly! Exiting...."
+          exit 1
+      fi
+      tar -zxf "spark-${SPARK_VERSION}-bin-k8s.tgz"
+      cd "spark-${SPARK_VERSION}-bin-k8s/"
+      SPARK_DIR=$CRAFT_PART_INSTALL/opt/spark
+      mkdir -p $SPARK_DIR/bin
+      cp -r bin/* $SPARK_DIR/bin
+      mkdir -p $SPARK_DIR/jars
+      cp -r jars/* $SPARK_DIR/jars
+      mkdir -p $SPARK_DIR/python
+      cp -r python/* $SPARK_DIR/python/
 
     override-prime: |
-        snapcraftctl prime
-        rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs 
-        # move base certs data
-        mv etc/ssl/certs/java/cacerts etc/cacerts
+      snapcraftctl prime
+      rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs
+      # move base certs data
+      mv etc/ssl/certs/java/cacerts etc/cacerts
+
   kubectl:
     plugin: nil
     build-packages:
-        - curl
+      - curl
     source: .
     source-type: local
     override-build: |


### PR DESCRIPTION
Working
- Authenticated connection
- History file
- TLS

Testing locally:

- Clone the branch
- Pack the snap with `snapcraft pack`
- Install the locally packed charm with `sudo snap install ./spark-client_3.5.1_amd64.snap --dangerous`
- Run the client against a deployment with `spark-client.beeline -u "jdbc:hive2://10.1.111.103:10009/" -n admin -p password`. Please note that we need the unit IP and not the hostname provided by core dns

Using TLS:
- Get the CA from `self-signed-certificates` as usual (using the action, or through `data-integrator`) in a `ca.pem` file
- Import the .pem file into a truststore in the snap using `spark-client.import-certificate ca ./ca.pem`
- Use `spark-client.beeline -u "jdbc:hive2://10.1.111.103:10009/;ssl=true" -n user -p password`