### PR TITLE
fix: Remove leading slash

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ apps:
       - dot-kube-config
 
   beeline:
-    command: /opt/spark/bin/beeline
+    command: opt/spark/bin/beeline
     environment:
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:


### PR DESCRIPTION
This PR removes the leading slash in the beeline command definition.
This was working locally, but leading to an error during the upload