### PR TITLE
[PRA-211] Reorder PYTHONPATH to give priority to the snap's stdlib

### DIFF
--- a/snap/local/etc/spark8t/launcher.sh
+++ b/snap/local/etc/spark8t/launcher.sh
@@ -4,4 +4,8 @@ if [[ ! -n "$KUBECONFIG" ]]; then
   KUBECONFIG="$SNAP_REAL_HOME/.kube/config"
 fi
 
+if [[ -n "$PYTHONPATH" ]]; then
+  PYTHONPATH="/usr/lib/python310.zip:/usr/lib/python3.10:/usr/lib/python3.10/lib-dynload:$SNAP/lib/python3.10/site-packages:$PYTHONPATH"
+fi
+
 KUBECONFIG=$KUBECONFIG exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ plugs:
 
 environment:
   JAVA_HOME: $SNAP/usr/lib/jvm/java-17-openjdk-${CRAFT_ARCH_BUILD_FOR}
-  PATH: $JAVA_HOME/bin:$PATH:$SNAP:$SNAP/opt/$CRAFT_PROJECT_NAME:$SNAP/opt/k8s:$SNAP/opt/spark
+  PATH: $JAVA_HOME/bin:$SNAP/bin:$SNAP/opt/$CRAFT_PROJECT_NAME:$SNAP/opt/k8s:$SNAP/opt/spark:$PATH
   SPARK_HOME: $SNAP/opt/spark
   SPARK_CONFS: $SNAP_DATA/etc/spark8t/
   SPARK_USER_DATA: $HOME
@@ -34,26 +34,22 @@ environment:
 
 apps:
   service-account-registry:
-    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/service_account_registry.py
-    environment:
-      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$SNAP/local/lib/dist-packages/:$SNAP/local/lib/dist-packages/spark8t/cli:$PYTHONPATH
+    command: etc/spark8t/launcher.sh $SNAP/bin/service-account-registry
     plugs:
       - network
       - home
       - dot-kube-config
   spark-submit:
-    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_submit.py
+    command: etc/spark8t/launcher.sh $SNAP/bin/spark-submit
     environment:
-      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
       - network
       - home
       - dot-kube-config
   spark-shell:
-    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_shell.py $SPARK8T_EXTRA_CONF
+    command: etc/spark8t/launcher.sh $SNAP/bin/spark-shell $SPARK8T_EXTRA_CONF
     environment:
-      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
@@ -62,9 +58,8 @@ apps:
       - home
       - dot-kube-config
   pyspark:
-    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/pyspark.py $SPARK8T_EXTRA_CONF
+    command: etc/spark8t/launcher.sh $SNAP/bin/pyspark $SPARK8T_EXTRA_CONF
     environment:
-      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
@@ -73,9 +68,8 @@ apps:
       - home
       - dot-kube-config
   spark-sql:
-    command: etc/spark8t/launcher.sh $SNAP/lib/python3.10/site-packages/spark8t/cli/spark_sql.py $SPARK8T_EXTRA_CONF
+    command: etc/spark8t/launcher.sh $SNAP/bin/spark-sql $SPARK8T_EXTRA_CONF
     environment:
-      PYTHONPATH: $SNAP/python:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
       SPARK8T_EXTRA_CONF: --conf spark.driver.extraJavaOptions="-Duser.home=$SNAP_USER_DATA" --conf spark.jars.ivy=/tmp
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA -Djavax.net.ssl.trustStore=$SNAP_DATA/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     plugs:
@@ -114,16 +108,10 @@ parts:
 
   spark8t:
     plugin: python
-    python-packages:
-      - spark8t==1.3.1
-    source: .
-    build-packages:
-      - python3
-      - pip
-    override-build: |
-      craftctl default
-      # Scripts must be executable
-      chmod -R 755 $CRAFT_PART_INSTALL/lib/python3.10/site-packages/spark8t/cli/
+    # TODO: replace with new release
+    source-type: git
+    source: https://github.com/canonical/spark-k8s-toolkit-py/
+    source-branch: wip-entrypoints
 
   spark:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,10 +112,9 @@ parts:
 
   spark8t:
     plugin: python
-    # TODO: replace with new release
-    source-type: git
-    source: https://github.com/canonical/spark-k8s-toolkit-py/
-    source-branch: wip-entrypoints
+    python-packages:
+      - spark8t == 1.4.0
+    source: ""
 
   spark:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,6 +4,13 @@ version: "3.5.7"
 summary: Client side scripts to submit Spark jobs to a cluster.
 description: |
   The spark-client snap includes the scripts spark-submit, spark-shell, pyspark and other tools for managing Apache Spark jobs.
+source-code: https://github.com/canonical/spark-client-snap
+issues: https://github.com/canonical/spark-client-snap/issues/new/choose
+website:
+  - https://ubuntu.com/data/spark
+  - https://canonical.com/data/docs/spark/k8s
+contact: https://matrix.to/#/%23charmhub-analytics%3Aubuntu.com
+license: Apache-2.0
 
 architectures:
   - build-on: [amd64]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,10 +83,7 @@ apps:
     environment:
       _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:
-      - network
-      - network-bind
       - home
-      - dot-kube-config
 
   beeline:
     command: opt/spark/bin/beeline


### PR DESCRIPTION
This PR addresses #145.

## Changes

We now have a dedicated condition in the wrapper script to make sure that the internal Python modules come first, should the user override PYTHONPATH.
This takes care of the issue demonstrated in the link above.

Given
```text
 .
 └── src
     └── types.py
```

```shell
PYTHONPATH=src spark-client-test.service-account-registry list
``` 
now works without trying to import `MappingProxyType` from the local file.

However, this PR still allows to extend the PYTHONPATH to give access to third-party libraries in `pyspark`.

```shell
uv venv venv --python 3.10
uv pip install numpy
PYTHONPATH=venv/lib/python3.10/site-packages spark-client-test.pyspark --username <user> --namespace <ns>
```

lets us import and use numpy in the pyspark shell.

I also added a few fields that were missing from snapcraft.yaml to make the snapcraft linter happier.