### PR TITLE
[MISC] Reduce the K8s matrix validation and disable fail-fast feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
       - build
     strategy:
       matrix:
+        fail-fast: false
         system:
           - os: ubuntu-22.04
             arch: amd64
@@ -27,11 +28,8 @@ jobs:
             arch: arm64
         k8s_version:
           - "1.28"
-          - "1.29"
           - "1.30"
-          - "1.31"
           - "1.32"
-          - "1.33"
           - "1.34"
     steps:
       - name: Download snap file


### PR DESCRIPTION
I noticed that when one of the workflows fail becuaes of any reasons, then all the other runs are cancelled. This seems a bit too strict, so I added the `fail-fast` option, and also reduced the K8s versions to just making it a bit more likely to happen