### PR TITLE
[MISC] Fix permissions for snap release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,4 +53,5 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write # Needed to create GitHub release


### PR DESCRIPTION
The shared workflow `release_snap_edge` requires permission `actions:read`.